### PR TITLE
Fixing a small bug when notifying a syntax error

### DIFF
--- a/Character-sameAs.st
+++ b/Character-sameAs.st
@@ -1,0 +1,8 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #2974] on 22 November 2016 at 12:51:23 pm'!
+
+!Character methodsFor: 'testing' stamp: 'KenD 11/22/2016 07:56:19'!
+sameAs: otherChar
+
+	(self class) = (otherChar class) ifFalse: [ ^ false ].
+	
+	^(self asLowercase) = (otherChar asLowercase)! !

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Regular Expressions for Cuis
 
 Tested in Cuis 5.0 rev 2984
 
-To install in a Cuis 4.2 image, open a Workspace and DoIt:
+STATUS: Port in progress; 144 Unit Tests FAIL
+
+To install in a Cuis image, open a Workspace and DoIt:
 
 ````Smalltalk
    Feature require: #'RegEx-Tests'.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 Cuis-Smalltalk-RegEx
 ====================
 
-Regular Expressions for Cuis
+Regular Expressions for Cuis.
 
 Tested in Cuis 5.0 rev 2984
 
-STATUS: Port in progress; 144 Unit Tests FAIL
+This is a port of Vassili Bykov's regular expression parser.
+
+He has released this as open source -- see method 
+   RxParser class>>f:boringStuff
+
 
 To install in a Cuis image, open a Workspace and DoIt:
 
 ````Smalltalk
-   Feature require: #'RegEx-Tests'.
+   Feature require: #'Regex-Tests'.
 ````
+
+Original port by German Arduino -- https://github.com/garduino
+Cuis updated based on port by Phil Bella -- https://github.com/pbella
+Updates integrated by Ken Dickey -- https://github.com/KenDickey

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-Cuis-RegEx
-==========
+Cuis-Smalltalk-RegEx
+====================
 
 Regular Expressions for Cuis
 
-Tested in Cuis 4.2 rev 2984
+Tested in Cuis 5.0 rev 2984
 
 To install in a Cuis 4.2 image, open a Workspace and DoIt:
 
 ````Smalltalk
-   Feature require: #'Regex-Tests-Core'.
+   Feature require: #'RegEx-Tests'.
 ````

--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@ Cuis-RegEx
 
 Regular Expressions for Cuis
 
-To install in a Cuis 4.1 image:
+Tested in Cuis 4.2 rev 2984
 
-1. Install Cuis-CompatibilityWithOtherSmalltalks
-2. Install RegEx-Core and RegEx-Tests
+To install in a Cuis 4.2 image, open a Workspace and DoIt:
 
-The 188 tests are green. 
-
-Last Update: 25/12/2012.
+````Smalltalk
+   Feature require: #'Regex-Tests-Core'.
+````

--- a/Regex-Core.pck.st
+++ b/Regex-Core.pck.st
@@ -1,6 +1,10 @@
-'From Cuis 5.0 of 7 November 2016 [latest update: #2974] on 22 November 2016 at 1:16:44 pm'!
-'Description Please enter a description for this package '!
-!provides: 'RegEx-Core' 1 3!
+'From Cuis 5.0 of 7 November 2016 [latest update: #2984] on 25 November 2016 at 4:37:34 pm'!
+'Description Reguar expression matching.
+See RegEx-Core RxParser class DOCUMENTATION methods and examples in Regex-Tests-Core.
+Copyright is in RegEx-Core RxParser class DOCUMENTATION f:boringStuff:
+  ''The Regular Expression Matcher (``The Software'''') is Copyright (C) 1996, 1999 Vassili Bykov. '' 
+ '!
+!provides: 'RegEx-Core' 1 7!
 !requires: 'Cuis-Base' 50 2974 nil!
 !requires: 'SqueakCompatibility' 1 27 nil!
 !classDefinition: #RegexError category: #'Regex-Core-Exceptions'!
@@ -581,10 +585,10 @@ addChar: aChar
 
 	elements add: (RxsCharacter with: aChar)! !
 
-!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
+!RxCharSetParser methodsFor: 'parsing' stamp: 'KenD 11/25/2016 15:53:46'!
 addRangeFrom: firstChar to: lastChar
 
-	firstChar asInteger > lastChar asInteger ifTrue:
+	firstChar numericValue > lastChar numericValue ifTrue:
 		[RxParser signalSyntaxException: ' bad character range'].
 	elements add: (RxsRange from: firstChar to: lastChar)! !
 
@@ -675,7 +679,7 @@ canStartMatch: aCharacter in: aMatcher
 	aCharacter isNil ifTrue: [^true].
 	^testBlock == nil or: [testBlock value: aCharacter value: aMatcher]! !
 
-!RxMatchOptimizer methodsFor: 'accessing' stamp: 'KenD 11/22/2016 13:08:58'!
+!RxMatchOptimizer methodsFor: 'accessing' stamp: 'KenD 11/25/2016 15:56:12'!
 conditionTester
 	"#any condition is filtered at the higher level;
 	it cannot appear among the conditions here."
@@ -695,11 +699,11 @@ conditionTester
 	"More than one condition. Capture them as an array in scope."
 	matchCondition := conditions asArray.
 	^[:c :matcher |
-		matchCondition includes:
+		matchCondition anySatisfy: "was #includes:"
 			[:conditionSelector |
 			matcher perform: conditionSelector]]! !
 
-!RxMatchOptimizer methodsFor: 'private' stamp: 'KenD 11/22/2016 13:09:05'!
+!RxMatchOptimizer methodsFor: 'private' stamp: 'KenD 11/25/2016 15:58:02'!
 determineTestMethod
 	"Answer a block closure that will work as a can-match predicate.
 	Answer nil if no viable optimization is possible (too many chars would
@@ -717,7 +721,8 @@ determineTestMethod
 	testers isEmpty ifTrue: [^nil].
 	testers size = 1 ifTrue: [^testers first].
 	testers := testers asArray.
-	^[:char :matcher | testers includes: [:t | t value: char value: matcher]]! !
+	"^[:char :matcher | testers includes: [:t | t value: char value: matcher]]"
+	^ [:char :matcher | testers anySatisfy: [:t | t value: char value: matcher]]! !
 
 !RxMatchOptimizer methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
 initialize: aRegex ignoreCase: aBoolean 
@@ -941,10 +946,10 @@ allocateMarker
 	markerCount := markerCount + 1.
 	^markerCount! !
 
-!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
+!RxMatcher methodsFor: 'testing' stamp: 'KenD 11/25/2016 16:06:50'!
 atBeginningOfLine
 
-	^self position = 0 or: [self lastChar = Cr]! !
+	^self position = 0 or: [self lastChar isLineSeparator]! !
 
 !RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
 atBeginningOfWord
@@ -957,10 +962,10 @@ atEnd
 
 	^stream atEnd! !
 
-!RxMatcher methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+!RxMatcher methodsFor: 'testing' stamp: 'KenD 11/25/2016 16:07:03'!
 atEndOfLine
 
-	^self atEnd or: [stream peek = Cr]! !
+	^self atEnd or: [stream peek isLineSeparator]! !
 
 !RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
 atEndOfWord
@@ -1382,13 +1387,16 @@ supportsSubexpressions
 
 	^true! !
 
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+!RxMatcher methodsFor: 'double dispatch' stamp: 'KenD 11/25/2016 16:26:52'!
 syntaxAny
 	"Double dispatch from the syntax tree. 
 	Create a matcher for any non-null character."
 
 	^RxmPredicate new
-		predicate: [:char | char asInteger ~= 0]! !
+		predicate: [:char | char numericValue ~= 0]
+	"?? Could match non-whitespace character
+		predicate: [:char | char isSeparator not]
+	"! !
 
 !RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
 syntaxBeginningOfLine
@@ -1404,7 +1412,7 @@ syntaxBeginningOfWord
 
 	^RxmSpecial new beBeginningOfWord! !
 
-!RxMatcher methodsFor: 'double dispatch' stamp: 'PeterHugossonMiller 9/3/2009 11:08'!
+!RxMatcher methodsFor: 'double dispatch' stamp: 'KenD 11/25/2016 16:28:11'!
 syntaxBranch: branchNode
 	"Double dispatch from the syntax tree. 
 	Branch node is a link in a chain of concatenated pieces.
@@ -1415,7 +1423,7 @@ syntaxBranch: branchNode
 		ifTrue: [^branchNode piece dispatchTo: self].
 	"Optimization: glue a sequence of individual characters into a single string to match."
 	branchNode piece isAtomic ifTrue:
-		[result := (String new: 40) writeStream.
+		[result := WriteStream on: (String new: 40).
 		next := branchNode tryMergingInto: result.
 		result := result contents.
 		result size > 1 ifTrue: "worth merging"
@@ -3152,10 +3160,10 @@ enumerableSetIgnoringCase: aBoolean
 			[each enumerateTo: set ignoringCase: aBoolean]].
 	^set! !
 
-!RxsCharSet methodsFor: 'accessing' stamp: 'KenD 11/22/2016 13:09:30'!
+!RxsCharSet methodsFor: 'accessing' stamp: 'KenD 11/25/2016 16:32:49'!
 hasPredicates
 
-	^elements includes: [:some | some isEnumerable not]! !
+	^elements anySatisfy: [:some | some isEnumerable not]! !
 
 !RxsCharSet methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
 initializeElements: aCollection negated: aBoolean

--- a/Regex-Core.pck.st
+++ b/Regex-Core.pck.st
@@ -4,7 +4,7 @@ See RegEx-Core RxParser class DOCUMENTATION methods and examples in Regex-Tests-
 Copyright is in RegEx-Core RxParser class DOCUMENTATION f:boringStuff:
   ''The Regular Expression Matcher (``The Software'''') is Copyright (C) 1996, 1999 Vassili Bykov. '' 
  '!
-!provides: 'RegEx-Core' 1 7!
+!provides: 'Regex-Core' 1 7!
 !requires: 'Cuis-Base' 50 2974 nil!
 !requires: 'SqueakCompatibility' 1 27 nil!
 !classDefinition: #RegexError category: #'Regex-Core-Exceptions'!

--- a/Regex-Core.pck.st
+++ b/Regex-Core.pck.st
@@ -1,12 +1,16 @@
-'From Cuis 5.0 of 7 November 2016 [latest update: #2984] on 25 November 2016 at 4:37:34 pm'!
+'From Cuis 5.0 [latest update: #4360] on 24 November 2020 at 7:46:12 pm'!
 'Description Reguar expression matching.
 See RegEx-Core RxParser class DOCUMENTATION methods and examples in Regex-Tests-Core.
 Copyright is in RegEx-Core RxParser class DOCUMENTATION f:boringStuff:
   ''The Regular Expression Matcher (``The Software'''') is Copyright (C) 1996, 1999 Vassili Bykov. '' 
  '!
-!provides: 'Regex-Core' 1 7!
+!provides: 'Regex-Core' 1 9!
 !requires: 'Cuis-Base' 50 2974 nil!
 !requires: 'SqueakCompatibility' 1 27 nil!
+SystemOrganization addCategory: #'Regex-Core-Exceptions'!
+SystemOrganization addCategory: #'Regex-Core'!
+
+
 !classDefinition: #RegexError category: #'Regex-Core-Exceptions'!
 Error subclass: #RegexError
 	instanceVariableNames: ''
@@ -487,99 +491,6 @@ Instance variables:
 	branch		<RxsBranch>
 	regex		<RxsRegex | RxsEpsilon>!
 
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:31'!
-allRangesOfRegexMatches: rxString
-
-	^rxString asRegex matchingRangesIn: self! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:32'!
-allRegexMatches: rxString
-
-	^rxString asRegex matchesIn: self! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:32'!
-asRegex
-	"Compile the receiver as a regex matcher. May raise RxParser>>syntaxErrorSignal
-	or RxParser>>compilationErrorSignal.
-	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
-	Refer to `documentation' protocol of RxParser class for details."
-
-	^RxParser preferredMatcherClass for: (RxParser new parse: self)! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:33'!
-asRegexIgnoringCase
-	"Compile the receiver as a regex matcher. May raise RxParser>>syntaxErrorSignal
-	or RxParser>>compilationErrorSignal.
-	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
-	Refer to `documentation' protocol of RxParser class for details."
-
-	^RxParser preferredMatcherClass
-		for: (RxParser new parse: self)
-		ignoreCase: true! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:33'!
-copyWithRegex: rxString matchesReplacedWith: aString
-
-	^rxString asRegex
-		copy: self replacingMatchesWith: aString! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:33'!
-copyWithRegex: rxString matchesTranslatedUsing: aBlock
-
-	^rxString asRegex
-		copy: self translatingMatchesUsing: aBlock! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:34'!
-matchesRegex: regexString
-	"Test if the receiver matches a regex.  May raise RxParser>>regexErrorSignal or
-	child signals.
-	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
-	Refer to `documentation' protocol of RxParser class for details."
-
-	^regexString asRegex matches: self! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:34'!
-matchesRegexIgnoringCase: regexString
-	"Test if the receiver matches a regex.  May raise RxParser>>regexErrorSignal or
-	child signals.
-	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
-	Refer to `documentation' protocol of RxParser class for details."
-
-	^regexString asRegexIgnoringCase matches: self! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:34'!
-prefixMatchesRegex: regexString
-	"Test if the receiver's prefix matches a regex.	
-	May raise RxParser class>>regexErrorSignal or child signals.
-	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
-	Refer to `documentation' protocol of RxParser class for details."
-
-	^regexString asRegex matchesPrefix: self! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:35'!
-prefixMatchesRegexIgnoringCase: regexString
-	"Test if the receiver's prefix matches a regex.	
-	May raise RxParser class>>regexErrorSignal or child signals.
-	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
-	Refer to `documentation' protocol of RxParser class for details."
-
-	^regexString asRegexIgnoringCase matchesPrefix: self! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:35'!
-regex: rxString matchesCollect: aBlock
-
-	^rxString asRegex matchesIn: self collect: aBlock! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:35'!
-regex: rxString matchesDo: aBlock
-
-	^rxString asRegex matchesIn: self do: aBlock! !
-
-!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:36'!
-search: aString
-	"compatibility method to make regexp and strings work polymorphicly"
-	^ aString includesSubString: self! !
-
 !RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
 addChar: aChar
 
@@ -592,30 +503,19 @@ addRangeFrom: firstChar to: lastChar
 		[RxParser signalSyntaxException: ' bad character range'].
 	elements add: (RxsRange from: firstChar to: lastChar)! !
 
-!RxCharSetParser methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initialize: aStream
-
-	source := aStream.
-	lookahead := aStream next.
-	elements := OrderedCollection new! !
-
-!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
+!RxCharSetParser methodsFor: 'parsing' stamp: 'DF 10/21/2020 20:49:11'!
 match: aCharacter
 
 	aCharacter = lookahead
-		ifFalse: [RxParser signalSyntaxException: 'unexpected character: ', (String with: lookahead)].
+		ifFalse: [
+			RxParser signalSyntaxException:
+				(lookahead 
+					ifNil:['missing character']
+					ifNotNil:['unexpected character: ', (String with: lookahead)])
+			].
 	^source atEnd
 		ifTrue: [lookahead := nil]
 		ifFalse: [lookahead := source next]! !
-
-!RxCharSetParser methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-parse
-
-	lookahead = $- ifTrue:
-		[self addChar: $-.
-		self match: $-].
-	[lookahead isNil] whileFalse: [self parseStep].
-	^elements! !
 
 !RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
 parseCharOrRange
@@ -664,6 +564,22 @@ parseStep
 		[RxParser signalSyntaxException: 'invalid range'].
 	self parseCharOrRange! !
 
+!RxCharSetParser methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initialize: aStream
+
+	source := aStream.
+	lookahead := aStream next.
+	elements := OrderedCollection new! !
+
+!RxCharSetParser methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+parse
+
+	lookahead = $- ifTrue:
+		[self addChar: $-.
+		self match: $-].
+	[lookahead isNil] whileFalse: [self parseStep].
+	^elements! !
+
 !RxCharSetParser class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
 on: aStream
 
@@ -703,48 +619,6 @@ conditionTester
 			[:conditionSelector |
 			matcher perform: conditionSelector]]! !
 
-!RxMatchOptimizer methodsFor: 'private' stamp: 'KenD 11/25/2016 15:58:02'!
-determineTestMethod
-	"Answer a block closure that will work as a can-match predicate.
-	Answer nil if no viable optimization is possible (too many chars would
-	be able to start a match)."
-
-	| testers |
-	(conditions includes: #any) ifTrue: [^nil].
-	testers := OrderedCollection new: 5.
-	#(#prefixTester #nonPrefixTester #conditionTester #methodPredicateTester #nonMethodPredicateTester #predicateTester #nonPredicateTester)
-		do: 
-			[:selector | 
-			| tester |
-			tester := self perform: selector.
-			tester notNil ifTrue: [testers add: tester]].
-	testers isEmpty ifTrue: [^nil].
-	testers size = 1 ifTrue: [^testers first].
-	testers := testers asArray.
-	"^[:char :matcher | testers includes: [:t | t value: char value: matcher]]"
-	^ [:char :matcher | testers anySatisfy: [:t | t value: char value: matcher]]! !
-
-!RxMatchOptimizer methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initialize: aRegex ignoreCase: aBoolean 
-	"Set `testMethod' variable to a can-match predicate block:
-	two-argument block which accepts a lookahead character
-	and a matcher (presumably built from aRegex) and answers 
-	a boolean indicating whether a match could start at the given
-	lookahead. "
-
-	ignoreCase := aBoolean.
-	prefixes := Set new: 10.
-	nonPrefixes := Set new: 10.
-	conditions := Set new: 3.
-	methodPredicates := Set new: 3.
-	nonMethodPredicates := Set new: 3.
-	predicates := Set new: 3.
-	nonPredicates := Set new: 3.
-	aRegex dispatchTo: self.	"If the whole expression is nullable, 
-		end-of-line is an implicit can-match condition!!"
-	aRegex isNullable ifTrue: [conditions add: #atEndOfLine].
-	testBlock := self determineTestMethod! !
-
 !RxMatchOptimizer methodsFor: 'accessing' stamp: 'KenD 11/22/2016 13:09:10'!
 methodPredicateTester
 	| p selector |
@@ -777,6 +651,27 @@ nonMethodPredicateTester
 			[[:char :m | 
 			RxParser doHandlingMessageNotUnderstood:
 				[p includes: [:sel | (char perform: sel) not]]]]! !
+
+!RxMatchOptimizer methodsFor: 'private' stamp: 'KenD 11/25/2016 15:58:02'!
+determineTestMethod
+	"Answer a block closure that will work as a can-match predicate.
+	Answer nil if no viable optimization is possible (too many chars would
+	be able to start a match)."
+
+	| testers |
+	(conditions includes: #any) ifTrue: [^nil].
+	testers := OrderedCollection new: 5.
+	#(#prefixTester #nonPrefixTester #conditionTester #methodPredicateTester #nonMethodPredicateTester #predicateTester #nonPredicateTester)
+		do: 
+			[:selector | 
+			| tester |
+			tester := self perform: selector.
+			tester notNil ifTrue: [testers add: tester]].
+	testers isEmpty ifTrue: [^nil].
+	testers size = 1 ifTrue: [^testers first].
+	testers := testers asArray.
+	"^[:char :matcher | testers includes: [:t | t value: char value: matcher]]"
+	^ [:char :matcher | testers anySatisfy: [:t | t value: char value: matcher]]! !
 
 !RxMatchOptimizer methodsFor: 'private' stamp: 'KenD 11/22/2016 13:09:20'!
 nonPredicateTester
@@ -841,6 +736,27 @@ prefixTester
 			[ignoreCase
 				ifTrue: [[:char :matcher | p includes: char asUppercase]]
 				ifFalse: [[:char :matcher | p includes: char]]]! !
+
+!RxMatchOptimizer methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initialize: aRegex ignoreCase: aBoolean 
+	"Set `testMethod' variable to a can-match predicate block:
+	two-argument block which accepts a lookahead character
+	and a matcher (presumably built from aRegex) and answers 
+	a boolean indicating whether a match could start at the given
+	lookahead. "
+
+	ignoreCase := aBoolean.
+	prefixes := Set new: 10.
+	nonPrefixes := Set new: 10.
+	conditions := Set new: 3.
+	methodPredicates := Set new: 3.
+	nonMethodPredicates := Set new: 3.
+	predicates := Set new: 3.
+	nonPredicates := Set new: 3.
+	aRegex dispatchTo: self.	"If the whole expression is nullable, 
+		end-of-line is an implicit can-match condition!!"
+	aRegex isNullable ifTrue: [conditions add: #atEndOfLine].
+	testBlock := self determineTestMethod! !
 
 !RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
 syntaxAny
@@ -946,129 +862,6 @@ allocateMarker
 	markerCount := markerCount + 1.
 	^markerCount! !
 
-!RxMatcher methodsFor: 'testing' stamp: 'KenD 11/25/2016 16:06:50'!
-atBeginningOfLine
-
-	^self position = 0 or: [self lastChar isLineSeparator]! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
-atBeginningOfWord
-
-	^(self isWordChar: self lastChar) not
-		and: [self isWordChar: stream peek]! !
-
-!RxMatcher methodsFor: 'streaming' stamp: 'vb 4/11/09 21:56'!
-atEnd
-
-	^stream atEnd! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'KenD 11/25/2016 16:07:03'!
-atEndOfLine
-
-	^self atEnd or: [stream peek isLineSeparator]! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
-atEndOfWord
-
-	^(self isWordChar: self lastChar)
-		and: [(self isWordChar: stream peek) not]! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
-atWordBoundary
-
-	^(self isWordChar: self lastChar)
-		xor: (self isWordChar: stream peek)! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-buildFrom: aSyntaxTreeRoot
-	"Private - Entry point of matcher build process."
-
-	markerCount := 0.  "must go before #dispatchTo: !!"
-	matcher := aSyntaxTreeRoot dispatchTo: self.
-	matcher terminateWith: RxmTerminator new! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-copy: aString replacingMatchesWith: replacementString
-	"Copy <aString>, except for the matches. Replace each match with <aString>."
-
-	| answer |
-	answer := (String new: 40) writeStream.
-	self
-		copyStream: aString readStream
-		to: answer
-		replacingMatchesWith: replacementString.
-	^answer contents! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-copy: aString translatingMatchesUsing: aBlock
-	"Copy <aString>, except for the matches. For each match, evaluate <aBlock> passing the matched substring as the argument.  Expect the block to answer a String, and replace the match with the answer."
-
-	| answer |
-	answer := (String new: 40) writeStream.
-	self copyStream: aString readStream to: answer translatingMatchesUsing: aBlock.
-	^answer contents! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'lr 1/15/2010 21:45'!
-copyStream: aStream to: writeStream replacingMatchesWith: aString
-	"Copy the contents of <aStream> on the <writeStream>, except for the matches. Replace each match with <aString>."
-
-	| searchStart matchStart matchEnd |
-	stream := aStream.
-	markerPositions := nil.
-	[searchStart := aStream position.
-	self proceedSearchingStream: aStream] whileTrue:
-		[matchStart := (self subBeginning: 1) first.
-		matchEnd := (self subEnd: 1) first.
-		aStream position: searchStart.
-		searchStart to: matchStart - 1 do:
-			[:ignoredPos | writeStream nextPut: aStream next].
-		writeStream nextPutAll: aString.
-		aStream position: matchEnd.
-		"Be extra careful about successful matches which consume no input.
-		After those, make sure to advance or finish if already at end."
-		matchEnd = searchStart ifTrue: 
-			[aStream atEnd
-				ifTrue:	[^self "rest after end of whileTrue: block is a no-op if atEnd"]
-				ifFalse:	[writeStream nextPut: aStream next]]].
-	aStream position: searchStart.
-	[aStream atEnd] whileFalse: [writeStream nextPut: aStream next]! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'lr 1/15/2010 21:45'!
-copyStream: aStream to: writeStream translatingMatchesUsing: aBlock
-	"Copy the contents of <aStream> on the <writeStream>, except for the matches. For each match, evaluate <aBlock> passing the matched substring as the argument.  Expect the block to answer a String, and write the answer to <writeStream> in place of the match."
-
-	| searchStart matchStart matchEnd match |
-	stream := aStream.	
-	markerPositions := nil.
-	[searchStart := aStream position.
-	self proceedSearchingStream: aStream] whileTrue:
-		[matchStart := (self subBeginning: 1) first.
-		matchEnd := (self subEnd: 1) first.
-		aStream position: searchStart.
-		searchStart to: matchStart - 1 do:
-			[:ignoredPos | writeStream nextPut: aStream next].
-		match := (String new: matchEnd - matchStart + 1) writeStream.
-		matchStart to: matchEnd - 1 do:
-			[:ignoredPos | match nextPut: aStream next].
-		writeStream nextPutAll: (aBlock value: match contents).
-		"Be extra careful about successful matches which consume no input.
-		After those, make sure to advance or finish if already at end."
-		matchEnd = searchStart ifTrue: 
-			[aStream atEnd
-				ifTrue:	[^self "rest after end of whileTrue: block is a no-op if atEnd"]
-				ifFalse:	[writeStream nextPut: aStream next]]].
-	aStream position: searchStart.
-	[aStream atEnd] whileFalse: [writeStream nextPut: aStream next]! !
-
-!RxMatcher methodsFor: 'privileged' stamp: 'lr 1/15/2010 21:13'!
-currentState
-	"Answer an opaque object that can later be used to restore the
-	matcher's state (for backtracking)."
-
-	| origPosition origLastChar |
-	origPosition := stream position.
-	^	[stream position: origPosition]! !
-
 !RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
 hookBranchOf: regexNode onto: endMarker
 	"Private - Recurse down the chain of regexes starting at
@@ -1086,18 +879,6 @@ hookBranchOf: regexNode onto: endMarker
 		alternative: rest;
 		yourself! !
 
-!RxMatcher methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initialize: syntaxTreeRoot ignoreCase: aBoolean
-	"Compile thyself for the regex with the specified syntax tree.
-	See comment and `building' protocol in this class and 
-	#dispatchTo: methods in syntax tree components for details 
-	on double-dispatch building. 
-	The argument is supposedly a RxsRegex."
-
-	ignoreCase := aBoolean.
-	self buildFrom: syntaxTreeRoot.
-	startOptimizer := RxMatchOptimizer new initialize: syntaxTreeRoot ignoreCase: aBoolean! !
-
 !RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
 isWordChar: aCharacterOrNil
 	"Answer whether the argument is a word constituent character:
@@ -1105,16 +886,6 @@ isWordChar: aCharacterOrNil
 
 	^aCharacterOrNil ~~ nil
 		and: [aCharacterOrNil isAlphaNumeric]! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'lr 1/15/2010 21:14'!
-lastChar
-	^ stream position = 0
-		ifFalse: [ stream skip: -1; next ]! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-lastResult
-
-	^lastResult! !
 
 !RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
 makeOptional: aMatcher
@@ -1156,84 +927,117 @@ makeStar: aMatcher
 	aMatcher pointTailTo: loopback.
 	^detour! !
 
-!RxMatcher methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
-markerPositionAt: anIndex add: position
-	"Remember position of another instance of the given marker."
+!RxMatcher methodsFor: 'private' stamp: 'lr 1/15/2010 21:17'!
+proceedSearchingStream: aStream
 
-	(markerPositions at: anIndex) addFirst: position! !
+	| position |
+	position := aStream position.
+	[aStream atEnd] whileFalse:
+		[self tryMatch ifTrue: [^true].
+		aStream position: position; next.
+		position := aStream position].
+	"Try match at the very stream end too!!"
+	self tryMatch ifTrue: [^true]. 
+	^false! !
+
+!RxMatcher methodsFor: 'private' stamp: 'lr 1/15/2010 21:51'!
+tryMatch
+	"Match thyself against the current stream."
+
+	| oldMarkerPositions |
+	oldMarkerPositions := markerPositions.
+	markerPositions := Array new: markerCount.
+	1 to: markerCount do: [ :i | markerPositions at: i put: OrderedCollection new ].
+	lastResult := startOptimizer isNil
+		ifTrue: [ matcher matchAgainst: self]
+		ifFalse: [ (startOptimizer canStartMatch: stream peek in: self) and: [ matcher matchAgainst: self ] ].
+	"check for duplicates"
+	(lastResult not or: [ oldMarkerPositions isNil or: [ oldMarkerPositions size ~= markerPositions size ] ])
+		ifTrue: [ ^ lastResult ].
+	oldMarkerPositions with: markerPositions do: [ :oldPos :newPos |
+		oldPos size = newPos size 
+			ifFalse: [ ^ lastResult ].
+		oldPos with: newPos do: [ :old :new |
+			old = new
+				ifFalse: [ ^ lastResult ] ] ].
+	"this is a duplicate"
+	^ lastResult := false! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'KenD 11/25/2016 16:06:50'!
+atBeginningOfLine
+
+	^self position = 0 or: [self lastChar isLineSeparator]! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
+atBeginningOfWord
+
+	^(self isWordChar: self lastChar) not
+		and: [self isWordChar: stream peek]! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'KenD 11/25/2016 16:07:03'!
+atEndOfLine
+
+	^self atEnd or: [stream peek isLineSeparator]! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
+atEndOfWord
+
+	^(self isWordChar: self lastChar)
+		and: [(self isWordChar: stream peek) not]! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
+atWordBoundary
+
+	^(self isWordChar: self lastChar)
+		xor: (self isWordChar: stream peek)! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+notAtWordBoundary
+
+	^self atWordBoundary not! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+supportsSubexpressions
+
+	^true! !
+
+!RxMatcher methodsFor: 'streaming' stamp: 'vb 4/11/09 21:56'!
+atEnd
+
+	^stream atEnd! !
+
+!RxMatcher methodsFor: 'streaming' stamp: 'lr 1/15/2010 21:13'!
+next
+	^ stream next! !
+
+!RxMatcher methodsFor: 'streaming' stamp: 'vb 4/11/09 21:56'!
+position
+
+	^stream position! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+buildFrom: aSyntaxTreeRoot
+	"Private - Entry point of matcher build process."
+
+	markerCount := 0.  "must go before #dispatchTo: !!"
+	matcher := aSyntaxTreeRoot dispatchTo: self.
+	matcher terminateWith: RxmTerminator new! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'lr 1/15/2010 21:14'!
+lastChar
+	^ stream position = 0
+		ifFalse: [ stream skip: -1; next ]! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+lastResult
+
+	^lastResult! !
 
 !RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
 matches: aString
 	"Match against a string."
 
 	^self matchesStream: aString readStream! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesIn: aString
-	"Search aString repeatedly for the matches of the receiver.  Answer an OrderedCollection of all matches (substrings)."
-
-	| result |
-	result := OrderedCollection new.
-	self
-		matchesOnStream: aString readStream
-		do: [:match | result add: match].
-	^result! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesIn: aString collect: aBlock
-	"Search aString repeatedly for the matches of the receiver.  Evaluate aBlock for each match passing the matched substring as the argument, collect evaluation results in an OrderedCollection, and return in. The following example shows how to use this message to split a string into words."
-	"'\w+' asRegex matchesIn: 'Now is the Time' collect: [:each | each asLowercase]"
-
-	| result |
-	result := OrderedCollection new.
-	self
-		matchesOnStream: aString readStream
-		do: [:match | result add: (aBlock value: match)].
-	^result! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesIn: aString do: aBlock
-	"Search aString repeatedly for the matches of the receiver.
-	Evaluate aBlock for each match passing the matched substring
-	as the argument."
-
-	self
-		matchesOnStream: aString readStream
-		do: aBlock! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesOnStream: aStream
-
-	| result |
-	result := OrderedCollection new.
-	self
-		matchesOnStream: aStream
-		do: [:match | result add: match].
-	^result! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesOnStream: aStream collect: aBlock
-
-	| result |
-	result := OrderedCollection new.
-	self
-		matchesOnStream: aStream
-		do: [:match | result add: (aBlock value: match)].
-	^result! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesOnStream: aStream do: aBlock
-	"Be extra careful about successful matches which consume no input.
-	After those, make sure to advance or finish if already at end."
-
-	| position |
-	[position := aStream position.
-	self searchStream: aStream] whileTrue:
-		[aBlock value: (self subexpression: 1).
-		position = aStream position ifTrue: 
-			[aStream atEnd
-				ifTrue: [^self]
-				ifFalse: [aStream next]]]! !
 
 !RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
 matchesPrefix: aString
@@ -1255,49 +1059,6 @@ matchesStreamPrefix: theStream
 	stream := theStream.
 	markerPositions := nil.
 	^self tryMatch! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchingRangesIn: aString
-	"Search aString repeatedly for the matches of the receiver.  Answer an OrderedCollection of ranges of each match (index of first character to: index of last character)."
-
-	| result |
-	result := OrderedCollection new.
-	self
-		matchesIn: aString 
-		do: [:match | result add: (self position - match size + 1 to: self position)].
-	^result! !
-
-!RxMatcher methodsFor: 'streaming' stamp: 'lr 1/15/2010 21:13'!
-next
-	^ stream next! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-notAtWordBoundary
-
-	^self atWordBoundary not! !
-
-!RxMatcher methodsFor: 'streaming' stamp: 'vb 4/11/09 21:56'!
-position
-
-	^stream position! !
-
-!RxMatcher methodsFor: 'private' stamp: 'lr 1/15/2010 21:17'!
-proceedSearchingStream: aStream
-
-	| position |
-	position := aStream position.
-	[aStream atEnd] whileFalse:
-		[self tryMatch ifTrue: [^true].
-		aStream position: position; next.
-		position := aStream position].
-	"Try match at the very stream end too!!"
-	self tryMatch ifTrue: [^true]. 
-	^false! !
-
-!RxMatcher methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
-restoreState: aBlock
-
-	aBlock value! !
 
 !RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
 search: aString
@@ -1382,10 +1143,188 @@ subexpressions: subIndex
 	stream position: originalPosition.
 	^reply asArray! !
 
-!RxMatcher methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-supportsSubexpressions
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+copy: aString replacingMatchesWith: replacementString
+	"Copy <aString>, except for the matches. Replace each match with <aString>."
 
-	^true! !
+	| answer |
+	answer := (String new: 40) writeStream.
+	self
+		copyStream: aString readStream
+		to: answer
+		replacingMatchesWith: replacementString.
+	^answer contents! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+copy: aString translatingMatchesUsing: aBlock
+	"Copy <aString>, except for the matches. For each match, evaluate <aBlock> passing the matched substring as the argument.  Expect the block to answer a String, and replace the match with the answer."
+
+	| answer |
+	answer := (String new: 40) writeStream.
+	self copyStream: aString readStream to: answer translatingMatchesUsing: aBlock.
+	^answer contents! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'lr 1/15/2010 21:45'!
+copyStream: aStream to: writeStream replacingMatchesWith: aString
+	"Copy the contents of <aStream> on the <writeStream>, except for the matches. Replace each match with <aString>."
+
+	| searchStart matchStart matchEnd |
+	stream := aStream.
+	markerPositions := nil.
+	[searchStart := aStream position.
+	self proceedSearchingStream: aStream] whileTrue:
+		[matchStart := (self subBeginning: 1) first.
+		matchEnd := (self subEnd: 1) first.
+		aStream position: searchStart.
+		searchStart to: matchStart - 1 do:
+			[:ignoredPos | writeStream nextPut: aStream next].
+		writeStream nextPutAll: aString.
+		aStream position: matchEnd.
+		"Be extra careful about successful matches which consume no input.
+		After those, make sure to advance or finish if already at end."
+		matchEnd = searchStart ifTrue: 
+			[aStream atEnd
+				ifTrue:	[^self "rest after end of whileTrue: block is a no-op if atEnd"]
+				ifFalse:	[writeStream nextPut: aStream next]]].
+	aStream position: searchStart.
+	[aStream atEnd] whileFalse: [writeStream nextPut: aStream next]! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'lr 1/15/2010 21:45'!
+copyStream: aStream to: writeStream translatingMatchesUsing: aBlock
+	"Copy the contents of <aStream> on the <writeStream>, except for the matches. For each match, evaluate <aBlock> passing the matched substring as the argument.  Expect the block to answer a String, and write the answer to <writeStream> in place of the match."
+
+	| searchStart matchStart matchEnd match |
+	stream := aStream.	
+	markerPositions := nil.
+	[searchStart := aStream position.
+	self proceedSearchingStream: aStream] whileTrue:
+		[matchStart := (self subBeginning: 1) first.
+		matchEnd := (self subEnd: 1) first.
+		aStream position: searchStart.
+		searchStart to: matchStart - 1 do:
+			[:ignoredPos | writeStream nextPut: aStream next].
+		match := (String new: matchEnd - matchStart + 1) writeStream.
+		matchStart to: matchEnd - 1 do:
+			[:ignoredPos | match nextPut: aStream next].
+		writeStream nextPutAll: (aBlock value: match contents).
+		"Be extra careful about successful matches which consume no input.
+		After those, make sure to advance or finish if already at end."
+		matchEnd = searchStart ifTrue: 
+			[aStream atEnd
+				ifTrue:	[^self "rest after end of whileTrue: block is a no-op if atEnd"]
+				ifFalse:	[writeStream nextPut: aStream next]]].
+	aStream position: searchStart.
+	[aStream atEnd] whileFalse: [writeStream nextPut: aStream next]! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesIn: aString
+	"Search aString repeatedly for the matches of the receiver.  Answer an OrderedCollection of all matches (substrings)."
+
+	| result |
+	result := OrderedCollection new.
+	self
+		matchesOnStream: aString readStream
+		do: [:match | result add: match].
+	^result! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesIn: aString collect: aBlock
+	"Search aString repeatedly for the matches of the receiver.  Evaluate aBlock for each match passing the matched substring as the argument, collect evaluation results in an OrderedCollection, and return in. The following example shows how to use this message to split a string into words."
+	"'\w+' asRegex matchesIn: 'Now is the Time' collect: [:each | each asLowercase]"
+
+	| result |
+	result := OrderedCollection new.
+	self
+		matchesOnStream: aString readStream
+		do: [:match | result add: (aBlock value: match)].
+	^result! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesIn: aString do: aBlock
+	"Search aString repeatedly for the matches of the receiver.
+	Evaluate aBlock for each match passing the matched substring
+	as the argument."
+
+	self
+		matchesOnStream: aString readStream
+		do: aBlock! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesOnStream: aStream
+
+	| result |
+	result := OrderedCollection new.
+	self
+		matchesOnStream: aStream
+		do: [:match | result add: match].
+	^result! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesOnStream: aStream collect: aBlock
+
+	| result |
+	result := OrderedCollection new.
+	self
+		matchesOnStream: aStream
+		do: [:match | result add: (aBlock value: match)].
+	^result! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesOnStream: aStream do: aBlock
+	"Be extra careful about successful matches which consume no input.
+	After those, make sure to advance or finish if already at end."
+
+	| position |
+	[position := aStream position.
+	self searchStream: aStream] whileTrue:
+		[aBlock value: (self subexpression: 1).
+		position = aStream position ifTrue: 
+			[aStream atEnd
+				ifTrue: [^self]
+				ifFalse: [aStream next]]]! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchingRangesIn: aString
+	"Search aString repeatedly for the matches of the receiver.  Answer an OrderedCollection of ranges of each match (index of first character to: index of last character)."
+
+	| result |
+	result := OrderedCollection new.
+	self
+		matchesIn: aString 
+		do: [:match | result add: (self position - match size + 1 to: self position)].
+	^result! !
+
+!RxMatcher methodsFor: 'privileged' stamp: 'lr 1/15/2010 21:13'!
+currentState
+	"Answer an opaque object that can later be used to restore the
+	matcher's state (for backtracking)."
+
+	| origPosition origLastChar |
+	origPosition := stream position.
+	^	[stream position: origPosition]! !
+
+!RxMatcher methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
+markerPositionAt: anIndex add: position
+	"Remember position of another instance of the given marker."
+
+	(markerPositions at: anIndex) addFirst: position! !
+
+!RxMatcher methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
+restoreState: aBlock
+
+	aBlock value! !
+
+!RxMatcher methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initialize: syntaxTreeRoot ignoreCase: aBoolean
+	"Compile thyself for the regex with the specified syntax tree.
+	See comment and `building' protocol in this class and 
+	#dispatchTo: methods in syntax tree components for details 
+	on double-dispatch building. 
+	The argument is supposedly a RxsRegex."
+
+	ignoreCase := aBoolean.
+	self buildFrom: syntaxTreeRoot.
+	startOptimizer := RxMatchOptimizer new initialize: syntaxTreeRoot ignoreCase: aBoolean! !
 
 !RxMatcher methodsFor: 'double dispatch' stamp: 'KenD 11/25/2016 16:26:52'!
 syntaxAny
@@ -1546,29 +1485,6 @@ syntaxWordBoundary
 
 	^RxmSpecial new beWordBoundary! !
 
-!RxMatcher methodsFor: 'private' stamp: 'lr 1/15/2010 21:51'!
-tryMatch
-	"Match thyself against the current stream."
-
-	| oldMarkerPositions |
-	oldMarkerPositions := markerPositions.
-	markerPositions := Array new: markerCount.
-	1 to: markerCount do: [ :i | markerPositions at: i put: OrderedCollection new ].
-	lastResult := startOptimizer isNil
-		ifTrue: [ matcher matchAgainst: self]
-		ifFalse: [ (startOptimizer canStartMatch: stream peek in: self) and: [ matcher matchAgainst: self ] ].
-	"check for duplicates"
-	(lastResult not or: [ oldMarkerPositions isNil or: [ oldMarkerPositions size ~= markerPositions size ] ])
-		ifTrue: [ ^ lastResult ].
-	oldMarkerPositions with: markerPositions do: [ :oldPos :newPos |
-		oldPos size = newPos size 
-			ifFalse: [ ^ lastResult ].
-		oldPos with: newPos do: [ :old :new |
-			old = new
-				ifFalse: [ ^ lastResult ] ] ].
-	"this is a duplicate"
-	^ lastResult := false! !
-
 !RxMatcher class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
 for: aRegex
 	"Create and answer a matcher that will match a regular expression
@@ -1695,6 +1611,55 @@ characterSet
 		spec := spec, ']', (self inputUpTo: $] nestedOn: $[ errorMessage: errorMessage)].
 	^self characterSetFrom: spec! !
 
+!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
+messagePredicate
+	"Match a message predicate specification: a selector (presumably
+	understood by a Character) enclosed in :'s ."
+
+	| spec negated |
+	spec := (self inputUpTo: $: errorMessage: ' no terminating ":"').
+	negated := false.
+	spec first = $^ ifTrue:
+		[negated := true.
+		spec := spec copyFrom: 2 to: spec size].
+	^RxsMessagePredicate new 
+		initializeSelector: spec asSymbol
+		negated: negated! !
+
+!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
+piece
+	"<piece> ::= <atom> | <atom>* | <atom>+ | <atom>?"
+
+	| atom errorMessage |
+	errorMessage := ' nullable closure'.
+	atom := self atom.
+	lookahead = $* ifTrue: 
+		[self next.
+		atom isNullable ifTrue: [self signalParseError: errorMessage].
+		^RxsPiece new initializeStarAtom: atom].
+	lookahead = $+ ifTrue: 
+		[self next.
+		atom isNullable ifTrue: [self signalParseError: errorMessage].
+		^RxsPiece new initializePlusAtom: atom].
+	lookahead = $? ifTrue: 
+		[self next.
+		atom isNullable ifTrue: [self signalParseError: errorMessage].
+		^RxsPiece new initializeOptionalAtom: atom].
+	^RxsPiece new initializeAtom: atom! !
+
+!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
+regex
+	"<regex> ::= e | <branch> `|' <regex>"
+
+	| branch regex |
+	branch := self branch.
+	(lookahead = #epsilon or: [lookahead = $)])
+		ifTrue: [regex := nil]
+		ifFalse: 
+			[self match: $|.
+			regex := self regex].
+	^RxsRegex new initializeBranch: branch regex: regex! !
+
 !RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
 characterSetFrom: setSpec
 	"<setSpec> is what goes between the brackets in a charset regex
@@ -1764,21 +1729,6 @@ match: aCharacter
 		ifTrue: [^self signalParseError].	"does not return"
 	self next! !
 
-!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
-messagePredicate
-	"Match a message predicate specification: a selector (presumably
-	understood by a Character) enclosed in :'s ."
-
-	| spec negated |
-	spec := (self inputUpTo: $: errorMessage: ' no terminating ":"').
-	negated := false.
-	spec first = $^ ifTrue:
-		[negated := true.
-		spec := spec copyFrom: 2 to: spec size].
-	^RxsMessagePredicate new 
-		initializeSelector: spec asSymbol
-		negated: negated! !
-
 !RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
 next
 	"Advance the input storing the just read character
@@ -1787,6 +1737,16 @@ next
 	input atEnd
 		ifTrue: [lookahead := #epsilon]
 		ifFalse: [lookahead := input next]! !
+
+!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+signalParseError
+
+	self class signalSyntaxException: 'Regex syntax error'! !
+
+!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+signalParseError: aString
+
+	self class signalSyntaxException: aString! !
 
 !RxParser methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
 parse: aString
@@ -1811,50 +1771,6 @@ parseStream: aStream
 	tree := self regex.
 	self match: #epsilon.
 	^tree! !
-
-!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
-piece
-	"<piece> ::= <atom> | <atom>* | <atom>+ | <atom>?"
-
-	| atom errorMessage |
-	errorMessage := ' nullable closure'.
-	atom := self atom.
-	lookahead = $* ifTrue: 
-		[self next.
-		atom isNullable ifTrue: [self signalParseError: errorMessage].
-		^RxsPiece new initializeStarAtom: atom].
-	lookahead = $+ ifTrue: 
-		[self next.
-		atom isNullable ifTrue: [self signalParseError: errorMessage].
-		^RxsPiece new initializePlusAtom: atom].
-	lookahead = $? ifTrue: 
-		[self next.
-		atom isNullable ifTrue: [self signalParseError: errorMessage].
-		^RxsPiece new initializeOptionalAtom: atom].
-	^RxsPiece new initializeAtom: atom! !
-
-!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
-regex
-	"<regex> ::= e | <branch> `|' <regex>"
-
-	| branch regex |
-	branch := self branch.
-	(lookahead = #epsilon or: [lookahead = $)])
-		ifTrue: [regex := nil]
-		ifFalse: 
-			[self match: $|.
-			regex := self regex].
-	^RxsRegex new initializeBranch: branch regex: regex! !
-
-!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-signalParseError
-
-	self class signalSyntaxException: 'Regex syntax error'! !
-
-!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-signalParseError: aString
-
-	self class signalSyntaxException: aString! !
 
 !RxParser class methodsFor: 'DOCUMENTATION' stamp: 'vb 4/11/09 21:56'!
 a: x introduction: xx 
@@ -2613,14 +2529,6 @@ VisualAge:
 
 	self error: 'comment only'! !
 
-!RxParser class methodsFor: 'exception signaling' stamp: 'lr 11/4/2009 22:37'!
-doHandlingMessageNotUnderstood: aBlock
-	"MNU should be trapped and resignaled as a match error in a few places in the matcher.
-	This method factors out this dialect-dependent code to make porting easier."
-	^ aBlock
-		on: MessageNotUnderstood
-		do: [:ex | RxParser signalMatchException: 'invalid predicate selector']! !
-
 !RxParser class methodsFor: 'DOCUMENTATION' stamp: 'vb 4/11/09 21:56'!
 e: x implementationNotes: xx
 "	
@@ -2726,6 +2634,26 @@ It is provided to the Smalltalk community in hope it will be useful.
 
 	self error: 'comment only'! !
 
+!RxParser class methodsFor: 'exception signaling' stamp: 'lr 11/4/2009 22:37'!
+doHandlingMessageNotUnderstood: aBlock
+	"MNU should be trapped and resignaled as a match error in a few places in the matcher.
+	This method factors out this dialect-dependent code to make porting easier."
+	^ aBlock
+		on: MessageNotUnderstood
+		do: [:ex | RxParser signalMatchException: 'invalid predicate selector']! !
+
+!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
+signalCompilationException: errorString
+	RegexCompilationError new signal: errorString! !
+
+!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
+signalMatchException: errorString
+	RegexMatchingError new signal: errorString! !
+
+!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
+signalSyntaxException: errorString
+	RegexSyntaxError new signal: errorString! !
+
 !RxParser class methodsFor: 'class initialization' stamp: 'avi 11/30/2003 13:26'!
 initialize
 	"self initialize"
@@ -2770,6 +2698,13 @@ parse: aString
 
 	^self new parse: aString! !
 
+!RxParser class methodsFor: 'utilities' stamp: 'avi 11/30/2003 13:23'!
+safelyParse: aString
+	"Parse the argument and return the result (the parse tree).
+	In case of a syntax error, return nil.
+	Exception handling here is dialect-dependent."
+	^ [self new parse: aString] on: RegexSyntaxError do: [:ex | nil]! !
+
 !RxParser class methodsFor: 'preferences' stamp: 'vb 4/11/09 21:56'!
 preferredMatcherClass
 	"The matcher to use. For now just one is available, but in
@@ -2779,25 +2714,6 @@ preferredMatcherClass
 	Parser is still more or less `central' thing in the whole package."
 
 	^RxMatcher! !
-
-!RxParser class methodsFor: 'utilities' stamp: 'avi 11/30/2003 13:23'!
-safelyParse: aString
-	"Parse the argument and return the result (the parse tree).
-	In case of a syntax error, return nil.
-	Exception handling here is dialect-dependent."
-	^ [self new parse: aString] on: RegexSyntaxError do: [:ex | nil]! !
-
-!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
-signalCompilationException: errorString
-	RegexCompilationError new signal: errorString! !
-
-!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
-signalMatchException: errorString
-	RegexMatchingError new signal: errorString! !
-
-!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
-signalSyntaxException: errorString
-	RegexSyntaxError new signal: errorString! !
 
 !RxmLink methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
 matchAgainst: aMatcher
@@ -2923,6 +2839,15 @@ bePerformNot: aSelector
 		[:char | 
 		RxParser doHandlingMessageNotUnderstood: [(char perform: aSelector) not]]! !
 
+!RxmPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+predicate: aBlock
+	"This link will match any single character for which <aBlock>
+	evaluates to true."
+
+	aBlock numArgs ~= 1 ifTrue: [self error: 'bad predicate block'].
+	predicate := aBlock.
+	^self! !
+
 !RxmPredicate methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
 matchAgainst: aMatcher
 	"Match if the predicate block evaluates to true when given the
@@ -2937,15 +2862,6 @@ matchAgainst: aMatcher
 		ifFalse:
 			[aMatcher restoreState: original.
 			^false]! !
-
-!RxmPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-predicate: aBlock
-	"This link will match any single character for which <aBlock>
-	evaluates to true."
-
-	aBlock numArgs ~= 1 ifTrue: [self error: 'bad predicate block'].
-	predicate := aBlock.
-	^self! !
 
 !RxmPredicate class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
 with: unaryBlock
@@ -3012,6 +2928,13 @@ initialize
 	super initialize.
 	self beCaseSensitive! !
 
+!RxmSubstring methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+substring: aString ignoreCase: aBoolean
+	"Match exactly this string."
+
+	sample := aString.
+	aBoolean ifTrue: [self beCaseInsensitive]! !
+
 !RxmSubstring methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
 matchAgainst: aMatcher
 	"Match if my sample stream is exactly the current prefix
@@ -3034,13 +2957,6 @@ matchAgainst: aMatcher
 sampleStream
 
 	^sample readStream! !
-
-!RxmSubstring methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-substring: aString ignoreCase: aBoolean
-	"Match exactly this string."
-
-	sample := aString.
-	aBoolean ifTrue: [self beCaseInsensitive]! !
 
 !RxmTerminator methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
 matchAgainst: aStream
@@ -3100,6 +3016,11 @@ dispatchTo: aMatcher
 
 	^aMatcher syntaxBranch: self! !
 
+!RxsBranch methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+piece
+
+	^piece! !
+
 !RxsBranch methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
 initializePiece: aPiece branch: aBranch
 	"See class comment for instance variables description."
@@ -3111,11 +3032,6 @@ initializePiece: aPiece branch: aBranch
 isNullable
 
 	^piece isNullable and: [branch isNil or: [branch isNullable]]! !
-
-!RxsBranch methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-piece
-
-	^piece! !
 
 !RxsBranch methodsFor: 'optimization' stamp: 'vb 4/11/09 21:56'!
 tryMergingInto: aStream
@@ -3137,6 +3053,30 @@ dispatchTo: aMatcher
 	will do whatever it has to."
 
 	^aMatcher syntaxCharSet: self! !
+
+!RxsCharSet methodsFor: 'accessing' stamp: 'KenD 11/25/2016 16:32:49'!
+hasPredicates
+
+	^elements anySatisfy: [:some | some isEnumerable not]! !
+
+!RxsCharSet methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+predicateIgnoringCase: aBoolean
+
+	| predicate enumerable |
+	enumerable := self enumerablePartPredicateIgnoringCase: aBoolean.
+	^self hasPredicates
+		ifFalse: [enumerable]
+		ifTrue:
+			[predicate := self predicatePartPredicate.
+			negated
+				ifTrue: [[:char | (enumerable value: char) and: [predicate value: char]]]
+				ifFalse: [[:char | (enumerable value: char) or: [predicate value: char]]]]! !
+
+!RxsCharSet methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+predicates
+
+	^(elements reject: [:some | some isEnumerable])
+		collect: [:each | each predicate]! !
 
 !RxsCharSet methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
 enumerablePartPredicateIgnoringCase: aBoolean
@@ -3160,29 +3100,6 @@ enumerableSetIgnoringCase: aBoolean
 			[each enumerateTo: set ignoringCase: aBoolean]].
 	^set! !
 
-!RxsCharSet methodsFor: 'accessing' stamp: 'KenD 11/25/2016 16:32:49'!
-hasPredicates
-
-	^elements anySatisfy: [:some | some isEnumerable not]! !
-
-!RxsCharSet methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializeElements: aCollection negated: aBoolean
-	"See class comment for instance variables description."
-
-	elements := aCollection.
-	negated := aBoolean! !
-
-!RxsCharSet methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isEnumerable
-
-	elements detect: [:some | some isEnumerable not] ifNone: [^true].
-	^false! !
-
-!RxsCharSet methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isNegated
-
-	^negated! !
-
 !RxsCharSet methodsFor: 'privileged' stamp: 'lr 11/4/2009 22:27'!
 optimalSetIgnoringCase: aBoolean
 	"Assuming the client with search the `set' using #includes:,
@@ -3195,19 +3112,6 @@ optimalSetIgnoringCase: aBoolean
 	^set size < 10
 		ifTrue: [set asArray]
 		ifFalse: [set]! !
-
-!RxsCharSet methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-predicateIgnoringCase: aBoolean
-
-	| predicate enumerable |
-	enumerable := self enumerablePartPredicateIgnoringCase: aBoolean.
-	^self hasPredicates
-		ifFalse: [enumerable]
-		ifTrue:
-			[predicate := self predicatePartPredicate.
-			negated
-				ifTrue: [[:char | (enumerable value: char) and: [predicate value: char]]]
-				ifFalse: [[:char | (enumerable value: char) or: [predicate value: char]]]]! !
 
 !RxsCharSet methodsFor: 'privileged' stamp: 'KenD 11/22/2016 13:09:41'!
 predicatePartPredicate
@@ -3229,11 +3133,23 @@ predicatePartPredicate
 		ifTrue:
 			[[:char | (predicates includes: [:some | some value: char]) not]]! !
 
-!RxsCharSet methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-predicates
+!RxsCharSet methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializeElements: aCollection negated: aBoolean
+	"See class comment for instance variables description."
 
-	^(elements reject: [:some | some isEnumerable])
-		collect: [:each | each predicate]! !
+	elements := aCollection.
+	negated := aBoolean! !
+
+!RxsCharSet methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isEnumerable
+
+	elements detect: [:some | some isEnumerable not] ifNone: [^true].
+	^false! !
+
+!RxsCharSet methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isNegated
+
+	^negated! !
 
 !RxsCharacter methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
 character
@@ -3356,6 +3272,16 @@ dispatchTo: aBuilder
 
 	^aBuilder syntaxMessagePredicate: self! !
 
+!RxsMessagePredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+negated
+
+	^negated! !
+
+!RxsMessagePredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+selector
+
+	^selector! !
+
 !RxsMessagePredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
 initializeSelector: aSelector
 	"The selector must be a one-argument message understood by Character."
@@ -3368,16 +3294,6 @@ initializeSelector: aSelector negated: aBoolean
 
 	selector := aSelector.
 	negated := aBoolean! !
-
-!RxsMessagePredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-negated
-
-	^negated! !
-
-!RxsMessagePredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-selector
-
-	^selector! !
 
 !RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
 atom
@@ -3398,6 +3314,17 @@ dispatchTo: aMatcher
 	will do whatever it has to."
 
 	^aMatcher syntaxPiece: self! !
+
+!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+max
+	"The value answered may be nil, indicating infinity."
+
+	^max! !
+
+!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+min
+
+	^min! !
 
 !RxsPiece methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
 initializeAtom: anAtom
@@ -3467,17 +3394,6 @@ isSingular
 isStar
 
 	^min = 0 and: [max == nil]! !
-
-!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-max
-	"The value answered may be nil, indicating infinity."
-
-	^max! !
-
-!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-min
-
-	^min! !
 
 !RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
 beAlphaNumeric
@@ -3589,25 +3505,6 @@ dispatchTo: anObject
 
 	^anObject syntaxPredicate: self! !
 
-!RxsPredicate methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isAtomic
-	"A predicate is a single character but the character is not known in advance."
-
-	^false! !
-
-!RxsPredicate methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isEnumerable
-
-	^false! !
-
-!RxsPredicate methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-negate
-
-	| tmp |
-	tmp := predicate.
-	predicate := negation.
-	negation := tmp! !
-
 !RxsPredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
 negated
 
@@ -3627,6 +3524,25 @@ predicateNegation
 value: aCharacter
 
 	^predicate value: aCharacter! !
+
+!RxsPredicate methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isAtomic
+	"A predicate is a single character but the character is not known in advance."
+
+	^false! !
+
+!RxsPredicate methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isEnumerable
+
+	^false! !
+
+!RxsPredicate methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+negate
+
+	| tmp |
+	tmp := predicate.
+	predicate := negation.
+	negation := tmp! !
 
 !RxsPredicate class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
 forEscapedLetter: aCharacter
@@ -3724,6 +3640,10 @@ dispatchTo: aMatcher
 
 	^aMatcher syntaxRegex: self! !
 
+!RxsRegex methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+regex
+	^regex! !
+
 !RxsRegex methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
 initializeBranch: aBranch regex: aRegex
 	"See class comment for instance variable description."
@@ -3736,9 +3656,98 @@ isNullable
 
 	^branch isNullable or: [regex notNil and: [regex isNullable]]! !
 
-!RxsRegex methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-regex
-	^regex! !
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:31'!
+allRangesOfRegexMatches: rxString
+
+	^rxString asRegex matchingRangesIn: self! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:32'!
+allRegexMatches: rxString
+
+	^rxString asRegex matchesIn: self! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:32'!
+asRegex
+	"Compile the receiver as a regex matcher. May raise RxParser>>syntaxErrorSignal
+	or RxParser>>compilationErrorSignal.
+	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
+	Refer to `documentation' protocol of RxParser class for details."
+
+	^RxParser preferredMatcherClass for: (RxParser new parse: self)! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:33'!
+asRegexIgnoringCase
+	"Compile the receiver as a regex matcher. May raise RxParser>>syntaxErrorSignal
+	or RxParser>>compilationErrorSignal.
+	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
+	Refer to `documentation' protocol of RxParser class for details."
+
+	^RxParser preferredMatcherClass
+		for: (RxParser new parse: self)
+		ignoreCase: true! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:33'!
+copyWithRegex: rxString matchesReplacedWith: aString
+
+	^rxString asRegex
+		copy: self replacingMatchesWith: aString! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:33'!
+copyWithRegex: rxString matchesTranslatedUsing: aBlock
+
+	^rxString asRegex
+		copy: self translatingMatchesUsing: aBlock! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:34'!
+matchesRegex: regexString
+	"Test if the receiver matches a regex.  May raise RxParser>>regexErrorSignal or
+	child signals.
+	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
+	Refer to `documentation' protocol of RxParser class for details."
+
+	^regexString asRegex matches: self! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:34'!
+matchesRegexIgnoringCase: regexString
+	"Test if the receiver matches a regex.  May raise RxParser>>regexErrorSignal or
+	child signals.
+	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
+	Refer to `documentation' protocol of RxParser class for details."
+
+	^regexString asRegexIgnoringCase matches: self! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:34'!
+prefixMatchesRegex: regexString
+	"Test if the receiver's prefix matches a regex.	
+	May raise RxParser class>>regexErrorSignal or child signals.
+	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
+	Refer to `documentation' protocol of RxParser class for details."
+
+	^regexString asRegex matchesPrefix: self! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:35'!
+prefixMatchesRegexIgnoringCase: regexString
+	"Test if the receiver's prefix matches a regex.	
+	May raise RxParser class>>regexErrorSignal or child signals.
+	This is a part of the Regular Expression Matcher package, (c) 1996, 1999 Vassili Bykov.
+	Refer to `documentation' protocol of RxParser class for details."
+
+	^regexString asRegexIgnoringCase matchesPrefix: self! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:35'!
+regex: rxString matchesCollect: aBlock
+
+	^rxString asRegex matchesIn: self collect: aBlock! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:35'!
+regex: rxString matchesDo: aBlock
+
+	^rxString asRegex matchesIn: self do: aBlock! !
+
+!String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:36'!
+search: aString
+	"compatibility method to make regexp and strings work polymorphicly"
+	^ aString includesSubString: self! !
 RxMatcher initialize!
 RxParser initialize!
 RxsPredicate initialize!

--- a/Regex-Core.pck.st
+++ b/Regex-Core.pck.st
@@ -1,6 +1,6 @@
 'From Cuis 5.0 of 7 November 2016 [latest update: #2974] on 22 November 2016 at 1:16:44 pm'!
 'Description Please enter a description for this package '!
-!provides: 'Regex-Core' 1 3!
+!provides: 'RegEx-Core' 1 3!
 !requires: 'Cuis-Base' 50 2974 nil!
 !requires: 'SqueakCompatibility' 1 27 nil!
 !classDefinition: #RegexError category: #'Regex-Core-Exceptions'!

--- a/Regex-Core.pck.st
+++ b/Regex-Core.pck.st
@@ -1,5 +1,8 @@
-'From Cuis 4.1 of 12 December 2012 [latest update: #1524] on 30 December 2012 at 6:00:39 pm'!
+'From Cuis 5.0 of 7 November 2016 [latest update: #2974] on 22 November 2016 at 1:16:44 pm'!
 'Description Please enter a description for this package '!
+!provides: 'Regex-Core' 1 3!
+!requires: 'Cuis-Base' 50 2974 nil!
+!requires: 'SqueakCompatibility' 1 27 nil!
 !classDefinition: #RegexError category: #'Regex-Core-Exceptions'!
 Error subclass: #RegexError
 	instanceVariableNames: ''
@@ -261,11 +264,11 @@ RxsRegex class
 	instanceVariableNames: ''!
 
 
-!RegexCompilationError commentStamp: 'Tbn 11/12/2010 22:38' prior: 0!
-This class represents compilation errors in regular expressions.!
-
 !RegexError commentStamp: 'Tbn 11/12/2010 22:37' prior: 0!
 This is a common superclass for errors in regular expressions.!
+
+!RegexCompilationError commentStamp: 'Tbn 11/12/2010 22:38' prior: 0!
+This class represents compilation errors in regular expressions.!
 
 !RegexMatchingError commentStamp: 'Tbn 11/12/2010 22:38' prior: 0!
 This class represents matching errors in regular expressions.!
@@ -274,877 +277,211 @@ This class represents matching errors in regular expressions.!
 This class represents syntax errors in regular expressions.!
 
 !RxCharSetParser commentStamp: 'Tbn 11/12/2010 23:13' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--I am a parser created to parse the insides of a character set ([...]) construct. I create and answer a collection of "elements", each being an instance of one of: RxsCharacter, RxsRange, or RxsPredicate.Instance Variables:	source	<Stream>	open on whatever is inside the square brackets we have to parse.	lookahead	<Character>	The current lookahead character	elements	<Collection of: <RxsCharacter|RxsRange|RxsPredicate>> Parsing result!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+I am a parser created to parse the insides of a character set ([...]) construct. I create and answer a collection of "elements", each being an instance of one of: RxsCharacter, RxsRange, or RxsPredicate.
+
+Instance Variables:
+
+	source	<Stream>	open on whatever is inside the square brackets we have to parse.
+	lookahead	<Character>	The current lookahead character
+	elements	<Collection of: <RxsCharacter|RxsRange|RxsPredicate>> Parsing result!
 
 !RxMatchOptimizer commentStamp: 'Tbn 11/12/2010 23:13' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--A match start optimizer, handy for searching a string. Takes a regex syntax tree and sets itself up so that prefix characters or matcher states that cannot start a match are later recognized with #canStartMatch:in: method.Used by RxMatcher, but can be used by other matchers (if implemented) as well.!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+A match start optimizer, handy for searching a string. Takes a regex syntax tree and sets itself up so that prefix characters or matcher states that cannot start a match are later recognized with #canStartMatch:in: method.
+
+Used by RxMatcher, but can be used by other matchers (if implemented) as well.!
 
 !RxMatcher commentStamp: 'Tbn 11/12/2010 23:13' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--This is a recursive regex matcher. Not strikingly efficient, but simple. Also, keeps track of matched subexpressions.  The life cycle goes as follows:1. Initialization. Accepts a syntax tree (presumably produced by RxParser) and compiles it into a matcher built of other classes in this category.2. Matching. Accepts a stream or a string and returns a boolean indicating whether the whole stream or its prefix -- depending on the message sent -- matches the regex.3. Subexpression query. After a successful match, and before any other match, the matcher may be queried about the range of specific stream (string) positions that matched to certain parenthesized subexpressions of the original expression.Any number of queries may follow a successful match, and any number or matches may follow a successful initialization.Note that `matcher' is actually a sort of a misnomer. The actual matcher is a web of Rxm* instances built by RxMatcher during initialization. RxMatcher is just the interface facade of this network.  It is also a builder of it, and also provides a stream-like protocol to easily access the stream being matched.Instance variables:	matcher				<RxmLink> The entry point into the actual matcher.	stream				<Stream> The stream currently being matched against.	markerPositions		<Array of: Integer> Positions of markers' matches.	markerCount		<Integer> Number of markers.	lastResult 			<Boolean> Whether the latest match attempt succeeded or not.	lastChar			<Character | nil> character last seen in the matcher stream!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+This is a recursive regex matcher. Not strikingly efficient, but simple. Also, keeps track of matched subexpressions.  The life cycle goes as follows:
+
+1. Initialization. Accepts a syntax tree (presumably produced by RxParser) and compiles it into a matcher built of other classes in this category.
+
+2. Matching. Accepts a stream or a string and returns a boolean indicating whether the whole stream or its prefix -- depending on the message sent -- matches the regex.
+
+3. Subexpression query. After a successful match, and before any other match, the matcher may be queried about the range of specific stream (string) positions that matched to certain parenthesized subexpressions of the original expression.
+
+Any number of queries may follow a successful match, and any number or matches may follow a successful initialization.
+
+Note that `matcher' is actually a sort of a misnomer. The actual matcher is a web of Rxm* instances built by RxMatcher during initialization. RxMatcher is just the interface facade of this network.  It is also a builder of it, and also provides a stream-like protocol to easily access the stream being matched.
+
+Instance variables:
+	matcher				<RxmLink> The entry point into the actual matcher.
+	stream				<Stream> The stream currently being matched against.
+	markerPositions		<Array of: Integer> Positions of markers' matches.
+	markerCount		<Integer> Number of markers.
+	lastResult 			<Boolean> Whether the latest match attempt succeeded or not.
+	lastChar			<Character | nil> character last seen in the matcher stream!
 
 !RxParser commentStamp: 'Tbn 11/12/2010 23:13' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--The regular expression parser. Translates a regular expression read from a stream into a parse tree. ('accessing' protocol). The tree can later be passed to a matcher initialization method.  All other classes in this category implement the tree. Refer to their comments for any details.Instance variables:	input		<Stream> A stream with the regular expression being parsed.	lookahead	<Character>!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+The regular expression parser. Translates a regular expression read from a stream into a parse tree. ('accessing' protocol). The tree can later be passed to a matcher initialization method.  All other classes in this category implement the tree. Refer to their comments for any details.
 
-!RxmBranch commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--This is a branch of a matching process. Either `next' chain should match, or `alternative', if not nil, should match. Since this is also used to build loopbacks to match repetitions, `loopback' variable indicates whether the instance is a loopback: it affects the matcher-building operations (which of the paths through the branch is to consider as the primary when we have to find the "tail" of a matcher construct).Instance variables	alternative		<RxmLink> to match if `next' fails to match.	loopback		<Boolean>!
+Instance variables:
+	input		<Stream> A stream with the regular expression being parsed.
+	lookahead	<Character>!
 
 !RxmLink commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--A matcher is built of a number of links interconnected into some intricate structure. Regardless of fancy stuff, any link (except for the terminator) has the next one. Any link can match against a stream of characters, recursively propagating the match to the next link. Any link supports a number of matcher-building messages. This superclass does all of the above. The class is not necessarily abstract. It may double as an empty string matcher: it recursively propagates the match to the next link, thus always matching nothing successfully.Principal method:	matchAgainst: aMatcher		Any subclass will reimplement this to test the state of the matcher, most		probably reading one or more characters from the matcher's stream, and		either decide it has matched and answer true, leaving matcher stream		positioned at the end of match, or answer false and restore the matcher		stream position to whatever it was before the matching attempt.Instance variables:	next		<RxmLink | RxmTerminator> The next link in the structure.!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+A matcher is built of a number of links interconnected into some intricate structure. Regardless of fancy stuff, any link (except for the terminator) has the next one. Any link can match against a stream of characters, recursively propagating the match to the next link. Any link supports a number of matcher-building messages. This superclass does all of the above. 
+
+The class is not necessarily abstract. It may double as an empty string matcher: it recursively propagates the match to the next link, thus always matching nothing successfully.
+
+Principal method:
+	matchAgainst: aMatcher
+		Any subclass will reimplement this to test the state of the matcher, most
+		probably reading one or more characters from the matcher's stream, and
+		either decide it has matched and answer true, leaving matcher stream
+		positioned at the end of match, or answer false and restore the matcher
+		stream position to whatever it was before the matching attempt.
+
+Instance variables:
+	next		<RxmLink | RxmTerminator> The next link in the structure.!
+
+!RxmBranch commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+This is a branch of a matching process. Either `next' chain should match, or `alternative', if not nil, should match. Since this is also used to build loopbacks to match repetitions, `loopback' variable indicates whether the instance is a loopback: it affects the matcher-building operations (which of the paths through the branch is to consider as the primary when we have to find the "tail" of a matcher construct).
+
+Instance variables
+	alternative		<RxmLink> to match if `next' fails to match.
+	loopback		<Boolean>!
 
 !RxmMarker commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--A marker is used to remember positions of match of certain points of a regular expression. The marker receives an identifying key from the Matcher and uses that key to report positions of successful matches to the Matcher.Instance variables:	index	<Object> Something that makes sense for the Matcher. Received from the latter during initalization and later passed to it to identify the receiver.!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+A marker is used to remember positions of match of certain points of a regular expression. The marker receives an identifying key from the Matcher and uses that key to report positions of successful matches to the Matcher.
+
+Instance variables:
+	index	<Object> Something that makes sense for the Matcher. Received from the latter during initalization and later passed to it to identify the receiver.!
 
 !RxmPredicate commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--Instance holds onto a one-argument block and matches exactly one character if the block evaluates to true when passed the character as the argument.Instance variables:	predicate		<BlockClosure>!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+Instance holds onto a one-argument block and matches exactly one character if the block evaluates to true when passed the character as the argument.
+
+Instance variables:
+	predicate		<BlockClosure>!
 
 !RxmSpecial commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--A special node that matches a specific matcher state rather than any input character.The state is either at-beginning-of-line or at-end-of-line.!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+A special node that matches a specific matcher state rather than any input character.
+The state is either at-beginning-of-line or at-end-of-line.!
 
 !RxmSubstring commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--Instance holds onto a string and matches exactly this string, and exactly once.Instance variables:	string 	<String>!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+Instance holds onto a string and matches exactly this string, and exactly once.
+
+Instance variables:
+	string 	<String>!
 
 !RxmTerminator commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--Instances of this class are used to terminate matcher's chains. When a match reaches this (an instance receives #matchAgainst: message), the match is considered to succeed. Instances also support building protocol of RxmLinks, with some restrictions.!
-
-!RxsBranch commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--A Branch is a Piece followed by a Branch or an empty string.Instance variables:	piece		<RxsPiece>	branch		<RxsBranch|RxsEpsilon>!
-
-!RxsCharSet commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--A character set corresponds to a [...] construct in the regular expression.Instance variables:	elements	<OrderedCollection> An element can be one of: RxsCharacter, RxsRange, or RxsPredicate.	negated		<Boolean>!
-
-!RxsCharacter commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--A character is a literal character that appears either in the expression itself or in a character set within an expression.Instance variables:	character		<Character>!
-
-!RxsContextCondition commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--One of a few special nodes more often representing special state of the match rather than a predicate on a character.  The ugly exception is the #any condition which *is* a predicate on a character.Instance variables:	kind		<Selector>!
-
-!RxsEpsilon commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--This is an empty string.  It terminates some of the recursive constructs.!
-
-!RxsMessagePredicate commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--A message predicate represents a condition on a character that is tested (at the match time) by sending a unary message to the character expecting a Boolean answer.Instance variables:	selector		<Symbol>!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+Instances of this class are used to terminate matcher's chains. When a match reaches this (an instance receives #matchAgainst: message), the match is considered to succeed. Instances also support building protocol of RxmLinks, with some restrictions.!
 
 !RxsNode commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--A generic syntax tree node, provides some common responses to the standard tests, as well as tree structure printing -- handy for debugging.!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+A generic syntax tree node, provides some common responses to the standard tests, as well as tree structure printing -- handy for debugging.!
+
+!RxsBranch commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+A Branch is a Piece followed by a Branch or an empty string.
+
+Instance variables:
+	piece		<RxsPiece>
+	branch		<RxsBranch|RxsEpsilon>!
+
+!RxsCharSet commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+A character set corresponds to a [...] construct in the regular expression.
+
+Instance variables:
+	elements	<OrderedCollection> An element can be one of: RxsCharacter, RxsRange, or RxsPredicate.
+	negated		<Boolean>!
+
+!RxsCharacter commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+A character is a literal character that appears either in the expression itself or in a character set within an expression.
+
+Instance variables:
+	character		<Character>!
+
+!RxsContextCondition commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+One of a few special nodes more often representing special state of the match rather than a predicate on a character.  The ugly exception is the #any condition which *is* a predicate on a character.
+
+Instance variables:
+	kind		<Selector>!
+
+!RxsEpsilon commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+This is an empty string.  It terminates some of the recursive constructs.!
+
+!RxsMessagePredicate commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+A message predicate represents a condition on a character that is tested (at the match time) by sending a unary message to the character expecting a Boolean answer.
+
+Instance variables:
+	selector		<Symbol>!
 
 !RxsPiece commentStamp: 'Tbn 11/12/2010 23:14' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--A piece is an atom, possibly optional or repeated a number of times.Instance variables:	atom	<RxsCharacter|RxsCharSet|RxsPredicate|RxsRegex|RxsSpecial>	min		<Integer>	max	<Integer|nil> nil means infinity!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+A piece is an atom, possibly optional or repeated a number of times.
+
+Instance variables:
+	atom	<RxsCharacter|RxsCharSet|RxsPredicate|RxsRegex|RxsSpecial>
+	min		<Integer>
+	max	<Integer|nil> nil means infinity!
 
 !RxsPredicate commentStamp: 'Tbn 11/12/2010 23:15' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--This represents a character that satisfies a certain predicate.Instance Variables:	predicate	<BlockClosure>	A one-argument block. If it evaluates to the value defined by <negated> when it is passed a character, the predicate is considered to match.	negation	<BlockClosure>	A one-argument block that is a negation of <predicate>.!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+This represents a character that satisfies a certain predicate.
+
+Instance Variables:
+
+	predicate	<BlockClosure>	A one-argument block. If it evaluates to the value defined by <negated> when it is passed a character, the predicate is considered to match.
+	negation	<BlockClosure>	A one-argument block that is a negation of <predicate>.!
 
 !RxsRange commentStamp: 'Tbn 11/12/2010 23:15' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--I represent a range of characters as appear in character classes such as	[a-ZA-Z0-9].I appear in a syntax tree only as an element of RxsCharSet.Instance Variables:	first	<Character>	last	<Character>!
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+I represent a range of characters as appear in character classes such as
+
+	[a-ZA-Z0-9].
+
+I appear in a syntax tree only as an element of RxsCharSet.
+
+Instance Variables:
+
+	first	<Character>
+	last	<Character>!
 
 !RxsRegex commentStamp: 'Tbn 11/12/2010 23:15' prior: 0!
--- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov--The body of a parenthesized thing, or a top-level expression, also an atom.  Instance variables:	branch		<RxsBranch>	regex		<RxsRegex | RxsEpsilon>!
-
-!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
-addChar: aChar	elements add: (RxsCharacter with: aChar)! !
-
-!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
-addRangeFrom: firstChar to: lastChar	firstChar asInteger > lastChar asInteger ifTrue:		[RxParser signalSyntaxException: ' bad character range'].	elements add: (RxsRange from: firstChar to: lastChar)! !
-
-!RxCharSetParser methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initialize: aStream	source := aStream.	lookahead := aStream next.	elements := OrderedCollection new! !
-
-!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
-match: aCharacter	aCharacter = lookahead		ifFalse: [RxParser signalSyntaxException: 'unexpected character: ', (String with: lookahead)].	^source atEnd		ifTrue: [lookahead := nil]		ifFalse: [lookahead := source next]! !
-
-!RxCharSetParser methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-parse	lookahead = $- ifTrue:		[self addChar: $-.		self match: $-].	[lookahead isNil] whileFalse: [self parseStep].	^elements! !
-
-!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
-parseCharOrRange	| firstChar |	firstChar := lookahead.	self match: firstChar.	lookahead = $- ifTrue:		[self match: $-.		lookahead isNil			ifTrue: [^self addChar: firstChar; addChar: $-]			ifFalse: 				[self addRangeFrom: firstChar to: lookahead.				^self match: lookahead]].	self addChar: firstChar! !
-
-!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
-parseEscapeChar	self match: $\.	$- = lookahead		ifTrue: [elements add: (RxsCharacter with: $-)]		ifFalse: [elements add: (RxsPredicate forEscapedLetter: lookahead)].	self match: lookahead! !
-
-!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
-parseNamedSet	| name |	self match: $[; match: $:.	name := (String with: lookahead), (source upTo: $:).	lookahead := source next.	self match: $].	elements add: (RxsPredicate forNamedClass: name)! !
-
-!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
-parseStep	lookahead = $[ ifTrue:		[source peek = $:			ifTrue: [^self parseNamedSet]			ifFalse: [^self parseCharOrRange]].	lookahead = $\ ifTrue:		[^self parseEscapeChar].	lookahead = $- ifTrue:		[RxParser signalSyntaxException: 'invalid range'].	self parseCharOrRange! !
-
-!RxCharSetParser class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
-on: aStream	^self new initialize: aStream! !
-
-!RxMatchOptimizer methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-canStartMatch: aCharacter in: aMatcher 	"Answer whether a match could commence at the given lookahead	character, or in the current state of <aMatcher>. True answered	by this method does not mean a match will definitly occur, while false	answered by this method *does* guarantee a match will never occur."	aCharacter isNil ifTrue: [^true].	^testBlock == nil or: [testBlock value: aCharacter value: aMatcher]! !
-
-!RxMatchOptimizer methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-conditionTester	"#any condition is filtered at the higher level;	it cannot appear among the conditions here."	| matchCondition |	conditions isEmpty ifTrue: [^nil].	conditions size = 1 ifTrue:		[matchCondition := conditions detect: [:ignored | true].		"Special case all of the possible conditions."		#atBeginningOfLine = matchCondition ifTrue: [^[:c :matcher | matcher atBeginningOfLine]].		#atEndOfLine = matchCondition ifTrue: [^[:c :matcher | matcher atEndOfLine]].		#atBeginningOfWord = matchCondition ifTrue: [^[:c :matcher | matcher atBeginningOfWord]].		#atEndOfWord = matchCondition ifTrue: [^[:c :matcher | matcher atEndOfWord]].		#atWordBoundary = matchCondition ifTrue: [^[:c :matcher | matcher atWordBoundary]].		#notAtWordBoundary = matchCondition ifTrue: [^[:c :matcher | matcher notAtWordBoundary]].		RxParser signalCompilationException: 'invalid match condition'].	"More than one condition. Capture them as an array in scope."	matchCondition := conditions asArray.	^[:c :matcher |		matchCondition contains:			[:conditionSelector |			matcher perform: conditionSelector]]! !
-
-!RxMatchOptimizer methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-determineTestMethod	"Answer a block closure that will work as a can-match predicate.	Answer nil if no viable optimization is possible (too many chars would	be able to start a match)."	| testers |	(conditions includes: #any) ifTrue: [^nil].	testers := OrderedCollection new: 5.	#(#prefixTester #nonPrefixTester #conditionTester #methodPredicateTester #nonMethodPredicateTester #predicateTester #nonPredicateTester)		do: 			[:selector | 			| tester |			tester := self perform: selector.			tester notNil ifTrue: [testers add: tester]].	testers isEmpty ifTrue: [^nil].	testers size = 1 ifTrue: [^testers first].	testers := testers asArray.	^[:char :matcher | testers contains: [:t | t value: char value: matcher]]! !
-
-!RxMatchOptimizer methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initialize: aRegex ignoreCase: aBoolean 	"Set `testMethod' variable to a can-match predicate block:	two-argument block which accepts a lookahead character	and a matcher (presumably built from aRegex) and answers 	a boolean indicating whether a match could start at the given	lookahead. "	ignoreCase := aBoolean.	prefixes := Set new: 10.	nonPrefixes := Set new: 10.	conditions := Set new: 3.	methodPredicates := Set new: 3.	nonMethodPredicates := Set new: 3.	predicates := Set new: 3.	nonPredicates := Set new: 3.	aRegex dispatchTo: self.	"If the whole expression is nullable, 		end-of-line is an implicit can-match condition!!"	aRegex isNullable ifTrue: [conditions add: #atEndOfLine].	testBlock := self determineTestMethod! !
-
-!RxMatchOptimizer methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-methodPredicateTester	| p selector |	methodPredicates isEmpty ifTrue: [^nil].	p := self optimizeSet: methodPredicates.	"also allows copying closures"	^p size = 1		ifTrue: 			["might be a pretty common case"			selector := p first.			[:char :matcher | 			RxParser doHandlingMessageNotUnderstood:				[char perform: selector]]]		ifFalse: 			[[:char :m | 			RxParser doHandlingMessageNotUnderstood:				[p contains: [:sel | char perform: sel]]]]! !
-
-!RxMatchOptimizer methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-nonMethodPredicateTester	| p selector |	nonMethodPredicates isEmpty ifTrue: [^nil].	p := self optimizeSet: nonMethodPredicates.	"also allows copying closures"	^p size = 1		ifTrue: 			[selector := p first.			[:char :matcher | 			RxParser doHandlingMessageNotUnderstood:				[(char perform: selector) not]]]		ifFalse: 			[[:char :m | 			RxParser doHandlingMessageNotUnderstood:				[p contains: [:sel | (char perform: sel) not]]]]! !
-
-!RxMatchOptimizer methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-nonPredicateTester	| p pred |	nonPredicates isEmpty ifTrue: [^nil].	p := self optimizeSet: nonPredicates.	"also allows copying closures"	^p size = 1		ifTrue: 			[pred := p first.			[:char :matcher | (pred value: char) not]]		ifFalse: 			[[:char :m | p contains: [:some | (some value: char) not]]]! !
-
-!RxMatchOptimizer methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-nonPrefixTester	| np nonPrefixChar |	nonPrefixes isEmpty ifTrue: [^nil].	np := self optimizeSet: nonPrefixes. "also allows copying closures"	^np size = 1 "might be be pretty common case"		ifTrue: 			[nonPrefixChar := np first.			[:char :matcher | char ~= nonPrefixChar]]		ifFalse: [[:char : matcher | (np includes: char) not]]! !
-
-!RxMatchOptimizer methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-optimizeSet: aSet	"If a set is small, convert it to array to speed up lookup	(Array has no hashing overhead, beats Set on small number	of elements)."	^aSet size < 10 ifTrue: [aSet asArray] ifFalse: [aSet]! !
-
-!RxMatchOptimizer methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-predicateTester	| p pred |	predicates isEmpty ifTrue: [^nil].	p := self optimizeSet: predicates.	"also allows copying closures"	^p size = 1		ifTrue: 			[pred := p first.			[:char :matcher | pred value: char]]		ifFalse: 			[[:char :m | p contains: [:some | some value: char]]]! !
-
-!RxMatchOptimizer methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-prefixTester	| p prefixChar |	prefixes isEmpty ifTrue: [^nil].	p := self optimizeSet: prefixes. "also allows copying closures"	ignoreCase ifTrue: [p := p collect: [:each | each asUppercase]].	^p size = 1 "might be a pretty common case"		ifTrue: 			[prefixChar := p first.			ignoreCase				ifTrue: [[:char :matcher | char sameAs: prefixChar]]				ifFalse: [[:char :matcher | char = prefixChar]]]		ifFalse:			[ignoreCase				ifTrue: [[:char :matcher | p includes: char asUppercase]]				ifFalse: [[:char :matcher | p includes: char]]]! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxAny	"Any special char is among the prefixes."	conditions add: #any! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxBeginningOfLine	"Beginning of line is among the prefixes."	conditions add: #atBeginningOfLine! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxBeginningOfWord	"Beginning of line is among the prefixes."	conditions add: #atBeginningOfWord! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxBranch: branchNode	"If the head piece of the branch is transparent (allows 0 matches),	we must recurse down the branch. Otherwise, just the head atom	is important."	(branchNode piece isNullable and: [branchNode branch notNil])		ifTrue: [branchNode branch dispatchTo: self].	branchNode piece dispatchTo: self! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxCharSet: charSetNode 	"All these (or none of these) characters is the prefix."	charSetNode isNegated		ifTrue: [nonPrefixes addAll: (charSetNode enumerableSetIgnoringCase: ignoreCase)]		ifFalse: [prefixes addAll: (charSetNode enumerableSetIgnoringCase: ignoreCase)].	charSetNode hasPredicates ifTrue: 			[charSetNode isNegated				ifTrue: [nonPredicates addAll: charSetNode predicates]				ifFalse: [predicates addAll: charSetNode predicates]]! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxCharacter: charNode	"This character is the prefix, of one of them."	prefixes add: charNode character! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxEndOfLine	"Beginning of line is among the prefixes."	conditions add: #atEndOfLine! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxEndOfWord	conditions add: #atEndOfWord! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxEpsilon	"Empty string, terminate the recursion (do nothing)."! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxMessagePredicate: messagePredicateNode 	messagePredicateNode negated		ifTrue: [nonMethodPredicates add: messagePredicateNode selector]		ifFalse: [methodPredicates add: messagePredicateNode selector]! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxNonWordBoundary	conditions add: #notAtWordBoundary! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxPiece: pieceNode	"Pass on to the atom."	pieceNode atom dispatchTo: self! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxPredicate: predicateNode 	predicates add: predicateNode predicate! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxRegex: regexNode	"All prefixes of the regex's branches should be combined.	Therefore, just recurse."	regexNode branch dispatchTo: self.	regexNode regex notNil		ifTrue: [regexNode regex dispatchTo: self]! !
-
-!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxWordBoundary	conditions add: #atWordBoundary! !
-
-!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-allocateMarker	"Answer an integer to use as an index of the next marker."	markerCount := markerCount + 1.	^markerCount! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
-atBeginningOfLine	^self position = 0 or: [self lastChar = Cr]! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
-atBeginningOfWord	^(self isWordChar: self lastChar) not		and: [self isWordChar: stream peek]! !
-
-!RxMatcher methodsFor: 'streaming' stamp: 'vb 4/11/09 21:56'!
-atEnd	^stream atEnd! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-atEndOfLine	^self atEnd or: [stream peek = Cr]! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
-atEndOfWord	^(self isWordChar: self lastChar)		and: [(self isWordChar: stream peek) not]! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
-atWordBoundary	^(self isWordChar: self lastChar)		xor: (self isWordChar: stream peek)! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-buildFrom: aSyntaxTreeRoot	"Private - Entry point of matcher build process."	markerCount := 0.  "must go before #dispatchTo: !!"	matcher := aSyntaxTreeRoot dispatchTo: self.	matcher terminateWith: RxmTerminator new! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-copy: aString replacingMatchesWith: replacementString	"Copy <aString>, except for the matches. Replace each match with <aString>."	| answer |	answer := (String new: 40) writeStream.	self		copyStream: aString readStream		to: answer		replacingMatchesWith: replacementString.	^answer contents! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-copy: aString translatingMatchesUsing: aBlock	"Copy <aString>, except for the matches. For each match, evaluate <aBlock> passing the matched substring as the argument.  Expect the block to answer a String, and replace the match with the answer."	| answer |	answer := (String new: 40) writeStream.	self copyStream: aString readStream to: answer translatingMatchesUsing: aBlock.	^answer contents! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'lr 1/15/2010 21:45'!
-copyStream: aStream to: writeStream replacingMatchesWith: aString	"Copy the contents of <aStream> on the <writeStream>, except for the matches. Replace each match with <aString>."	| searchStart matchStart matchEnd |	stream := aStream.	markerPositions := nil.	[searchStart := aStream position.	self proceedSearchingStream: aStream] whileTrue:		[matchStart := (self subBeginning: 1) first.		matchEnd := (self subEnd: 1) first.		aStream position: searchStart.		searchStart to: matchStart - 1 do:			[:ignoredPos | writeStream nextPut: aStream next].		writeStream nextPutAll: aString.		aStream position: matchEnd.		"Be extra careful about successful matches which consume no input.		After those, make sure to advance or finish if already at end."		matchEnd = searchStart ifTrue: 			[aStream atEnd				ifTrue:	[^self "rest after end of whileTrue: block is a no-op if atEnd"]				ifFalse:	[writeStream nextPut: aStream next]]].	aStream position: searchStart.	[aStream atEnd] whileFalse: [writeStream nextPut: aStream next]! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'lr 1/15/2010 21:45'!
-copyStream: aStream to: writeStream translatingMatchesUsing: aBlock	"Copy the contents of <aStream> on the <writeStream>, except for the matches. For each match, evaluate <aBlock> passing the matched substring as the argument.  Expect the block to answer a String, and write the answer to <writeStream> in place of the match."	| searchStart matchStart matchEnd match |	stream := aStream.		markerPositions := nil.	[searchStart := aStream position.	self proceedSearchingStream: aStream] whileTrue:		[matchStart := (self subBeginning: 1) first.		matchEnd := (self subEnd: 1) first.		aStream position: searchStart.		searchStart to: matchStart - 1 do:			[:ignoredPos | writeStream nextPut: aStream next].		match := (String new: matchEnd - matchStart + 1) writeStream.		matchStart to: matchEnd - 1 do:			[:ignoredPos | match nextPut: aStream next].		writeStream nextPutAll: (aBlock value: match contents).		"Be extra careful about successful matches which consume no input.		After those, make sure to advance or finish if already at end."		matchEnd = searchStart ifTrue: 			[aStream atEnd				ifTrue:	[^self "rest after end of whileTrue: block is a no-op if atEnd"]				ifFalse:	[writeStream nextPut: aStream next]]].	aStream position: searchStart.	[aStream atEnd] whileFalse: [writeStream nextPut: aStream next]! !
-
-!RxMatcher methodsFor: 'privileged' stamp: 'lr 1/15/2010 21:13'!
-currentState	"Answer an opaque object that can later be used to restore the	matcher's state (for backtracking)."	| origPosition origLastChar |	origPosition := stream position.	^	[stream position: origPosition]! !
-
-!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-hookBranchOf: regexNode onto: endMarker	"Private - Recurse down the chain of regexes starting at	regexNode, compiling their branches and hooking their tails 	to the endMarker node."	| rest |	rest := regexNode regex isNil		ifTrue: [nil]		ifFalse: [self hookBranchOf: regexNode regex onto: endMarker].	^RxmBranch new		next: ((regexNode branch dispatchTo: self)					pointTailTo: endMarker; 					yourself);		alternative: rest;		yourself! !
-
-!RxMatcher methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initialize: syntaxTreeRoot ignoreCase: aBoolean	"Compile thyself for the regex with the specified syntax tree.	See comment and `building' protocol in this class and 	#dispatchTo: methods in syntax tree components for details 	on double-dispatch building. 	The argument is supposedly a RxsRegex."	ignoreCase := aBoolean.	self buildFrom: syntaxTreeRoot.	startOptimizer := RxMatchOptimizer new initialize: syntaxTreeRoot ignoreCase: aBoolean! !
-
-!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-isWordChar: aCharacterOrNil	"Answer whether the argument is a word constituent character:	alphanumeric or _."	^aCharacterOrNil ~~ nil		and: [aCharacterOrNil isAlphaNumeric]! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'lr 1/15/2010 21:14'!
-lastChar	^ stream position = 0		ifFalse: [ stream skip: -1; next ]! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-lastResult	^lastResult! !
-
-!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-makeOptional: aMatcher	"Private - Wrap this matcher so that the result would match 0 or 1	occurrences of the matcher."	| dummy branch |	dummy := RxmLink new.	branch := (RxmBranch new beLoopback)		next: aMatcher;		alternative: dummy.	aMatcher pointTailTo: dummy.	^branch! !
-
-!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-makePlus: aMatcher	"Private - Wrap this matcher so that the result would match 1 and more	occurrences of the matcher."	| loopback |	loopback := (RxmBranch new beLoopback)		next: aMatcher.	aMatcher pointTailTo: loopback.	^aMatcher! !
-
-!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-makeStar: aMatcher	"Private - Wrap this matcher so that the result would match 0 and more	occurrences of the matcher."	| dummy detour loopback |	dummy := RxmLink new.	detour := RxmBranch new		next: aMatcher;		alternative: dummy.	loopback := (RxmBranch new beLoopback)		next: aMatcher;		alternative: dummy.	aMatcher pointTailTo: loopback.	^detour! !
-
-!RxMatcher methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
-markerPositionAt: anIndex add: position	"Remember position of another instance of the given marker."	(markerPositions at: anIndex) addFirst: position! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-matches: aString	"Match against a string."	^self matchesStream: aString readStream! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesIn: aString	"Search aString repeatedly for the matches of the receiver.  Answer an OrderedCollection of all matches (substrings)."	| result |	result := OrderedCollection new.	self		matchesOnStream: aString readStream		do: [:match | result add: match].	^result! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesIn: aString collect: aBlock	"Search aString repeatedly for the matches of the receiver.  Evaluate aBlock for each match passing the matched substring as the argument, collect evaluation results in an OrderedCollection, and return in. The following example shows how to use this message to split a string into words."	"'\w+' asRegex matchesIn: 'Now is the Time' collect: [:each | each asLowercase]"	| result |	result := OrderedCollection new.	self		matchesOnStream: aString readStream		do: [:match | result add: (aBlock value: match)].	^result! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesIn: aString do: aBlock	"Search aString repeatedly for the matches of the receiver.	Evaluate aBlock for each match passing the matched substring	as the argument."	self		matchesOnStream: aString readStream		do: aBlock! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesOnStream: aStream	| result |	result := OrderedCollection new.	self		matchesOnStream: aStream		do: [:match | result add: match].	^result! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesOnStream: aStream collect: aBlock	| result |	result := OrderedCollection new.	self		matchesOnStream: aStream		do: [:match | result add: (aBlock value: match)].	^result! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchesOnStream: aStream do: aBlock	"Be extra careful about successful matches which consume no input.	After those, make sure to advance or finish if already at end."	| position |	[position := aStream position.	self searchStream: aStream] whileTrue:		[aBlock value: (self subexpression: 1).		position = aStream position ifTrue: 			[aStream atEnd				ifTrue: [^self]				ifFalse: [aStream next]]]! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-matchesPrefix: aString	"Match against a string."	^self matchesStreamPrefix: aString readStream! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-matchesStream: theStream	"Match thyself against a positionable stream."	^(self matchesStreamPrefix: theStream)		and: [stream atEnd]! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'lr 1/15/2010 21:45'!
-matchesStreamPrefix: theStream	"Match thyself against a positionable stream."	stream := theStream.	markerPositions := nil.	^self tryMatch! !
-
-!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
-matchingRangesIn: aString	"Search aString repeatedly for the matches of the receiver.  Answer an OrderedCollection of ranges of each match (index of first character to: index of last character)."	| result |	result := OrderedCollection new.	self		matchesIn: aString 		do: [:match | result add: (self position - match size + 1 to: self position)].	^result! !
-
-!RxMatcher methodsFor: 'streaming' stamp: 'lr 1/15/2010 21:13'!
-next	^ stream next! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-notAtWordBoundary	^self atWordBoundary not! !
-
-!RxMatcher methodsFor: 'streaming' stamp: 'vb 4/11/09 21:56'!
-position	^stream position! !
-
-!RxMatcher methodsFor: 'private' stamp: 'lr 1/15/2010 21:17'!
-proceedSearchingStream: aStream	| position |	position := aStream position.	[aStream atEnd] whileFalse:		[self tryMatch ifTrue: [^true].		aStream position: position; next.		position := aStream position].	"Try match at the very stream end too!!"	self tryMatch ifTrue: [^true]. 	^false! !
-
-!RxMatcher methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
-restoreState: aBlock	aBlock value! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-search: aString	"Search the string for occurrence of something matching myself.	Answer a Boolean indicating success."	^self searchStream: aString readStream! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'lr 1/15/2010 21:45'!
-searchStream: aStream	"Search the stream for occurrence of something matching myself.	After the search has occurred, stop positioned after the end of the	matched substring. Answer a Boolean indicating success."	| position |	stream := aStream.	position := aStream position.	markerPositions := nil.	[aStream atEnd] whileFalse:		[self tryMatch ifTrue: [^true].		aStream position: position; next.		position := aStream position].	"Try match at the very stream end too!!"	self tryMatch ifTrue: [^true]. 	^false! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'jannik.laval 5/2/2010 06:53'!
-split: aString	| result lastPosition |	result := OrderedCollection new.	stream := aString readStream.	lastPosition := stream position.	[ self searchStream: stream ] whileTrue:		[ result add: (aString copyFrom: lastPosition+1 to: (self subBeginning: 1) first).		[lastPosition < stream position] assertWithDescription: 'Regex cannot match null string'.		lastPosition := stream position ].	result add: (aString copyFrom: lastPosition+1 to: aString size).	^ result! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-subBeginning: subIndex	^markerPositions at: subIndex * 2 - 1! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-subEnd: subIndex	^markerPositions at: subIndex * 2! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-subexpression: subIndex	"Answer a string that matched the subexpression at the given index.	If there are multiple matches, answer the last one.	If there are no matches, answer nil. 	(NB: it used to answer an empty string but I think nil makes more sense)."	| matches |	matches := self subexpressions: subIndex.	^matches isEmpty ifTrue: [nil] ifFalse: [matches last]! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-subexpressionCount	^markerCount // 2! !
-
-!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-subexpressions: subIndex	"Answer an array of all matches of the subexpression at the given index.	The answer is always an array; it is empty if there are no matches."	| originalPosition startPositions stopPositions reply |	originalPosition := stream position.	startPositions := self subBeginning: subIndex.	stopPositions := self subEnd: subIndex.	(startPositions isEmpty or: [stopPositions isEmpty]) ifTrue: [^Array new].	reply := OrderedCollection new.	startPositions with: stopPositions do:		[:start :stop |		stream position: start.		reply add: (stream next: stop - start)].	stream position: originalPosition.	^reply asArray! !
-
-!RxMatcher methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-supportsSubexpressions	^true! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxAny	"Double dispatch from the syntax tree. 	Create a matcher for any non-null character."	^RxmPredicate new		predicate: [:char | char asInteger ~= 0]! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxBeginningOfLine	"Double dispatch from the syntax tree. 	Create a matcher for beginning-of-line condition."	^RxmSpecial new beBeginningOfLine! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxBeginningOfWord	"Double dispatch from the syntax tree. 	Create a matcher for beginning-of-word condition."	^RxmSpecial new beBeginningOfWord! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'PeterHugossonMiller 9/3/2009 11:08'!
-syntaxBranch: branchNode	"Double dispatch from the syntax tree. 	Branch node is a link in a chain of concatenated pieces.	First build the matcher for the rest of the chain, then make 	it for the current piece and hook the rest to it."	| result next rest |	branchNode branch isNil		ifTrue: [^branchNode piece dispatchTo: self].	"Optimization: glue a sequence of individual characters into a single string to match."	branchNode piece isAtomic ifTrue:		[result := (String new: 40) writeStream.		next := branchNode tryMergingInto: result.		result := result contents.		result size > 1 ifTrue: "worth merging"			[rest := next notNil 				ifTrue: [next dispatchTo: self]				ifFalse: [nil].			^(RxmSubstring new substring: result ignoreCase: ignoreCase)				pointTailTo: rest;				yourself]].	"No optimization possible or worth it, just concatenate all. "	^(branchNode piece dispatchTo: self)		pointTailTo: (branchNode branch dispatchTo: self);		yourself! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxCharSet: charSetNode	"Double dispatch from the syntax tree. 	A character set is a few characters, and we either match any of them,	or match any that is not one of them."	^RxmPredicate with: (charSetNode predicateIgnoringCase: ignoreCase)! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxCharacter: charNode	"Double dispatch from the syntax tree. 	We get here when no merging characters into strings was possible."	| wanted |	wanted := charNode character.	^RxmPredicate new predicate: 		(ignoreCase			ifTrue: [[:char | char sameAs: wanted]]			ifFalse: [[:char | char = wanted]])! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxEndOfLine	"Double dispatch from the syntax tree. 	Create a matcher for end-of-line condition."	^RxmSpecial new beEndOfLine! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxEndOfWord	"Double dispatch from the syntax tree. 	Create a matcher for end-of-word condition."	^RxmSpecial new beEndOfWord! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxEpsilon	"Double dispatch from the syntax tree. Match empty string. This is unlikely	to happen in sane expressions, so we'll live without special epsilon-nodes."	^RxmSubstring new		substring: String new		ignoreCase: ignoreCase! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxMessagePredicate: messagePredicateNode	"Double dispatch from the syntax tree. 	Special link can handle predicates."	^messagePredicateNode negated		ifTrue: [RxmPredicate new bePerformNot: messagePredicateNode selector]		ifFalse: [RxmPredicate new bePerform: messagePredicateNode selector]! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxNonWordBoundary	"Double dispatch from the syntax tree. 	Create a matcher for the word boundary condition."	^RxmSpecial new beNotWordBoundary! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxPiece: pieceNode	"Double dispatch from the syntax tree. 	Piece is an atom repeated a few times. Take care of a special	case when the atom is repeated just once."	| atom |	atom := pieceNode atom dispatchTo: self.	^pieceNode isSingular		ifTrue: [atom]		ifFalse: [pieceNode isStar			ifTrue: [self makeStar: atom]			ifFalse: [pieceNode isPlus				ifTrue: [self makePlus: atom]				ifFalse: [pieceNode isOptional					ifTrue: [self makeOptional: atom]					ifFalse: [RxParser signalCompilationException: 						'repetitions are not supported by RxMatcher']]]]! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxPredicate: predicateNode	"Double dispatch from the syntax tree. 	A character set is a few characters, and we either match any of them,	or match any that is not one of them."	^RxmPredicate with: predicateNode predicate! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxRegex: regexNode	"Double dispatch from the syntax tree. 	Regex node is a chain of branches to be tried. Should compile this 	into a bundle of parallel branches, between two marker nodes." 		| startIndex endIndex endNode alternatives |	startIndex := self allocateMarker.	endIndex := self allocateMarker.	endNode := RxmMarker new index: endIndex.	alternatives := self hookBranchOf: regexNode onto: endNode.	^(RxmMarker new index: startIndex)		pointTailTo: alternatives;		yourself! !
-
-!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
-syntaxWordBoundary	"Double dispatch from the syntax tree. 	Create a matcher for the word boundary condition."	^RxmSpecial new beWordBoundary! !
-
-!RxMatcher methodsFor: 'private' stamp: 'lr 1/15/2010 21:51'!
-tryMatch	"Match thyself against the current stream."	| oldMarkerPositions |	oldMarkerPositions := markerPositions.	markerPositions := Array new: markerCount.	1 to: markerCount do: [ :i | markerPositions at: i put: OrderedCollection new ].	lastResult := startOptimizer isNil		ifTrue: [ matcher matchAgainst: self]		ifFalse: [ (startOptimizer canStartMatch: stream peek in: self) and: [ matcher matchAgainst: self ] ].	"check for duplicates"	(lastResult not or: [ oldMarkerPositions isNil or: [ oldMarkerPositions size ~= markerPositions size ] ])		ifTrue: [ ^ lastResult ].	oldMarkerPositions with: markerPositions do: [ :oldPos :newPos |		oldPos size = newPos size 			ifFalse: [ ^ lastResult ].		oldPos with: newPos do: [ :old :new |			old = new				ifFalse: [ ^ lastResult ] ] ].	"this is a duplicate"	^ lastResult := false! !
-
-!RxMatcher class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
-for: aRegex	"Create and answer a matcher that will match a regular expression	specified by the syntax tree of which `aRegex' is a root."	^self for: aRegex ignoreCase: false! !
-
-!RxMatcher class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
-for: aRegex ignoreCase: aBoolean	"Create and answer a matcher that will match a regular expression	specified by the syntax tree of which `aRegex' is a root."	^self new		initialize: aRegex		ignoreCase: aBoolean! !
-
-!RxMatcher class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
-forString: aString	"Create and answer a matcher that will match the regular expression	`aString'."	^self for: (RxParser new parse: aString)! !
-
-!RxMatcher class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
-forString: aString ignoreCase: aBoolean	"Create and answer a matcher that will match the regular expression	`aString'."	^self for: (RxParser new parse: aString) ignoreCase: aBoolean! !
-
-!RxMatcher class methodsFor: 'class initialization' stamp: 'avi 11/30/2003 13:30'!
-initialize	"RxMatcher initialize"	Cr := Character cr.	Lf := Character lf.! !
-
-!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
-atom	"An atom is one of a lot of possibilities, see below."	| atom |	(lookahead = #epsilon or: 			[lookahead = $| or: 					[lookahead = $)						or: [lookahead = $* or: [lookahead = $+ or: [lookahead = $?]]]]])		ifTrue: [^RxsEpsilon new].	lookahead = $( ifTrue: 			["<atom> ::= '(' <regex> ')' "			self match: $(.			atom := self regex.			self match: $).			^atom].	lookahead = $[ ifTrue: 			["<atom> ::= '[' <characterSet> ']' "			self match: $[.			atom := self characterSet.			self match: $].			^atom].	lookahead = $: ifTrue: 			["<atom> ::= ':' <messagePredicate> ':' "			self match: $:.			atom := self messagePredicate.			self match: $:.			^atom].	lookahead = $. ifTrue: 			["any non-whitespace character"			self next.			^RxsContextCondition new beAny].	lookahead = $^ ifTrue: 			["beginning of line condition"			self next.			^RxsContextCondition new beBeginningOfLine].	lookahead = $$ ifTrue: 			["end of line condition"			self next.			^RxsContextCondition new beEndOfLine].	lookahead = $\ ifTrue: 			["<atom> ::= '\' <character>"			self next.			lookahead = #epsilon ifTrue: 				[self signalParseError: 'bad quotation'].			(BackslashConstants includesKey: lookahead) ifTrue:				[atom := RxsCharacter with: (BackslashConstants at: lookahead).				self next.				^atom].			self ifSpecial: lookahead				then: [:node | self next. ^node]].	"If passed through the above, the following is a regular character."	atom := RxsCharacter with: lookahead.	self next.	^atom! !
-
-!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
-branch	"<branch> ::= e | <piece> <branch>"	| piece branch |	piece := self piece.	(lookahead = #epsilon or: [lookahead = $| or: [lookahead = $) ]])		ifTrue: [branch := nil]		ifFalse: [branch := self branch].	^RxsBranch new 		initializePiece: piece 		branch: branch! !
-
-!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
-characterSet	"Match a range of characters: something between `[' and `]'.	Opening bracked has already been seen, and closing should	not be consumed as well. Set spec is as usual for	sets in regexes."	| spec errorMessage |	errorMessage := ' no terminating "]"'.	spec := self inputUpTo: $] nestedOn: $[ errorMessage: errorMessage.	(spec isEmpty or: [spec = '^']) ifTrue: "This ']' was literal."		[self next.		spec := spec, ']', (self inputUpTo: $] nestedOn: $[ errorMessage: errorMessage)].	^self characterSetFrom: spec! !
-
-!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-characterSetFrom: setSpec	"<setSpec> is what goes between the brackets in a charset regex	(a String). Make a string containing all characters the spec specifies.	Spec is never empty."	| negated spec |	spec := ReadStream on: setSpec.	spec peek = $^		ifTrue: 	[negated := true.				spec next]		ifFalse:	[negated := false].	^RxsCharSet new		initializeElements: (RxCharSetParser on: spec) parse		negated: negated! !
-
-!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-ifSpecial: aCharacter then: aBlock	"If the character is such that it defines a special node when follows a $\,	then create that node and evaluate aBlock with the node as the parameter.	Otherwise just return."	| classAndSelector |	classAndSelector := BackslashSpecials at: aCharacter ifAbsent: [^self].	^aBlock value: (classAndSelector key new perform: classAndSelector value)! !
-
-!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-inputUpTo: aCharacter errorMessage: aString	"Accumulate input stream until <aCharacter> is encountered	and answer the accumulated chars as String, not including	<aCharacter>. Signal error if end of stream is encountered,	passing <aString> as the error description."	| accumulator |	accumulator := WriteStream on: (String new: 20).	[lookahead ~= aCharacter and: [lookahead ~= #epsilon]]		whileTrue:			[accumulator nextPut: lookahead.			self next].	lookahead = #epsilon ifTrue: [self signalParseError: aString].	^accumulator contents! !
-
-!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-inputUpTo: aCharacter nestedOn: anotherCharacter errorMessage: aString 	"Accumulate input stream until <aCharacter> is encountered	and answer the accumulated chars as String, not including	<aCharacter>. Signal error if end of stream is encountered,	passing <aString> as the error description."	| accumulator nestLevel |	accumulator := WriteStream on: (String new: 20).	nestLevel := 0.	[lookahead ~= aCharacter or: [nestLevel > 0]] whileTrue: 			[#epsilon = lookahead ifTrue: [self signalParseError: aString].			accumulator nextPut: lookahead.			lookahead = anotherCharacter ifTrue: [nestLevel := nestLevel + 1].			lookahead = aCharacter ifTrue: [nestLevel := nestLevel - 1].			self next].	^accumulator contents! !
-
-!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-match: aCharacter	"<aCharacter> MUST match the current lookeahead.	If this is the case, advance the input. Otherwise, blow up."	aCharacter ~= lookahead 		ifTrue: [^self signalParseError].	"does not return"	self next! !
-
-!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
-messagePredicate	"Match a message predicate specification: a selector (presumably	understood by a Character) enclosed in :'s ."	| spec negated |	spec := (self inputUpTo: $: errorMessage: ' no terminating ":"').	negated := false.	spec first = $^ ifTrue:		[negated := true.		spec := spec copyFrom: 2 to: spec size].	^RxsMessagePredicate new 		initializeSelector: spec asSymbol		negated: negated! !
-
-!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-next	"Advance the input storing the just read character	as the lookahead."	input atEnd		ifTrue: [lookahead := #epsilon]		ifFalse: [lookahead := input next]! !
-
-!RxParser methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-parse: aString	"Parse input from a string <aString>.	On success, answers an RxsRegex -- parse tree root.	On error, raises `RxParser syntaxErrorSignal' with the current	input stream position as the parameter."	^self parseStream: (ReadStream on: aString)! !
-
-!RxParser methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-parseStream: aStream	"Parse an input from a character stream <aStream>.	On success, answers an RxsRegex -- parse tree root.	On error, raises `RxParser syntaxErrorSignal' with the current	input stream position as the parameter."	| tree |	input := aStream.	lookahead := nil.	self match: nil.	tree := self regex.	self match: #epsilon.	^tree! !
-
-!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
-piece	"<piece> ::= <atom> | <atom>* | <atom>+ | <atom>?"	| atom errorMessage |	errorMessage := ' nullable closure'.	atom := self atom.	lookahead = $* ifTrue: 		[self next.		atom isNullable ifTrue: [self signalParseError: errorMessage].		^RxsPiece new initializeStarAtom: atom].	lookahead = $+ ifTrue: 		[self next.		atom isNullable ifTrue: [self signalParseError: errorMessage].		^RxsPiece new initializePlusAtom: atom].	lookahead = $? ifTrue: 		[self next.		atom isNullable ifTrue: [self signalParseError: errorMessage].		^RxsPiece new initializeOptionalAtom: atom].	^RxsPiece new initializeAtom: atom! !
-
-!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
-regex	"<regex> ::= e | <branch> `|' <regex>"	| branch regex |	branch := self branch.	(lookahead = #epsilon or: [lookahead = $)])		ifTrue: [regex := nil]		ifFalse: 			[self match: $|.			regex := self regex].	^RxsRegex new initializeBranch: branch regex: regex! !
-
-!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-signalParseError	self class signalSyntaxException: 'Regex syntax error'! !
-
-!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-signalParseError: aString	self class signalSyntaxException: aString! !
-
-!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'vb 4/11/09 21:56'!
-a: x introduction: xx " A regular expression is a template specifying a class of strings. Aregular expression matcher is an tool that determines whether a stringbelongs to a class specified by a regular expression.  This is acommon task of a user input validation code, and the use of regularexpressions can GREATLY simplify and speed up development of suchcode.  As an example, here is how to verify that a string is a validhexadecimal number in Smalltalk notation, using this matcher package:	aString matchesRegex: '16r[[:xdigit:]]+'(Coding the same ``the hard way'' is an exercise to a curious reader).This matcher is offered to the Smalltalk community in hope it will beuseful. It is free in terms of money, and to a large extent--in termsof rights of use. Refer to `Boring Stuff' section for legalese.The 'What's new in this release' section describes the functionalityintroduced in 1.1 release.The `Syntax' section explains the recognized syntax of regularexpressions.The `Usage' section explains matcher capabilities that go beyond whatString>>matchesRegex: method offers.The `Implementation notes' sections says a few words about what isunder the hood.Happy hacking,--Vassili Bykov <vassili@objectpeople.com> <vassili@magma.ca>August 6, 1996April 4, 1999"	self error: 'comment only'! !
-
-!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'lr 1/7/2010 20:10'!
-b: x whatsNewInThisRelease: xx"VERSION 1.3.1 (September 2008)1. Updated documentation of character classes, making clear the problems of locale - an area for future improvementVERSION 1.3 (September 2008)1. \w now matches underscore as well as alphanumerics, in line with most other regex libraries (and our documentation!!).  2. \W rejects underscore as well as alphanumerics3. added tests for this at end of testSuite4. updated documentation and added note to old incorrect comments in version 1.1 belowVERSION 1.2.3 (November 2007)1. Regexs with ^ or $ applied to copy empty strings caused infinite loops, e.g. ('' copyWithRegex: '^.*$' matchesReplacedWith: 'foo'). Applied a similar correction to that from version 1.1c, to #copyStream:to:(replacingMatchesWith:|translatingMatchesUsing:).2. Extended RxParser testing to run each test for #copy:translatingMatchesUsing: as well as #search:.3. Corrected #testSuite test that a dot does not match a null, which was passing by luck with Smalltalk code in a literal array.4. Added test to end of test suite for fix 1 above.VERSION 1.2.2 (November 2006)There was no way to specify a backslash in a character set. Now [\\] is accepted.VERSION 1.2.1	(August 2006)1. Support for returning all ranges (startIndex to: stopIndex) matching a regex - #allRangesOfRegexMatches:, #matchingRangesIn:2. Added hint to usage documentation on how to get more information about matches when enumerating3. Syntax description of dot corrected: matches anything but NUL since 1.1aVERSION 1.2	(May 2006)Fixed case-insensitive search for character sets.VERSION 1.1c	(December 2004)Fixed the issue with #matchesOnStream:do: which caused infinite loops for matches that matched empty strings.VERSION 1.1b	(November 2001)Changes valueNowOrOnUnwindDo: to ensure:, plus incorporates some earlier fixes.VERSION 1.1a	(May 2001)1. Support for keeping track of multiple subexpressions.2. Dot (.) matches anything but NUL character, as it should per POSIX spec.3. Some bug fixes.VERSION 1.1	(October 1999)Regular expression syntax corrections and enhancements:1. Backslash escapes similar to those in Perl are allowed in patterns:	\w	any word constituent character (equivalent to [a-zA-Z0-9_]) *** underscore only since 1.3 ***	\W	any character but a word constituent (equivalent to [^a-xA-Z0-9_] *** underscore only since 1.3 ***	\d	a digit (same as [0-9])	\D	anything but a digit	\s 	a whitespace character	\S	anything but a whitespace character	\b	an empty string at a word boundary	\B	an empty string not at a word boundary	\<	an empty string at the beginning of a word	\>	an empty string at the end of a wordFor example, '\w+' is now a valid expression matching any word.2. The following backslash escapes are also allowed in character sets(between square brackets):	\w, \W, \d, \D, \s, and \S.3. The following grep(1)-compatible named character classes arerecognized in character sets as well:	[:alnum:]	[:alpha:]	[:cntrl:]	[:digit:]	[:graph:]	[:lower:]	[:print:]	[:punct:]	[:space:]	[:upper:]	[:xdigit:]For example, the following patterns are equivalent:	'[[:alnum:]_]+' '\w+'  '[\w]+' '[a-zA-Z0-9_]+' *** underscore only since 1.3 ***4. Some non-printable characters can be represented in regularexpressions using a common backslash notation:	\t	tab (Character tab)	\n	newline (Character lf)	\r	carriage return (Character cr)	\f	form feed (Character newPage)	\e	escape (Character esc)5. A dot is corectly interpreted as 'any character but a newline'instead of 'anything but whitespace'.6. Case-insensitive matching.  The easiest access to it are newmessages CharacterArray understands: #asRegexIgnoringCase,#matchesRegexIgnoringCase:, #prefixMatchesRegexIgnoringCase:.7. The matcher (an instance of RxMatcher, the result ofString>>asRegex) now provides a collection-like interface to matchesin a particular string or on a particular stream, as well assubstitution protocol. The interface includes the following messages:	matchesIn: aString	matchesIn: aString collect: aBlock	matchesIn: aString do: aBlock	matchesOnStream: aStream	matchesOnStream: aStream collect: aBlock	matchesOnStream: aStream do: aBlock	copy: aString translatingMatchesUsing: aBlock	copy: aString replacingMatchesWith: replacementString	copyStream: aStream to: writeStream translatingMatchesUsing: aBlock	copyStream: aStream to: writeStream replacingMatchesWith: aStringExamples:	'\w+' asRegex matchesIn: 'now is the time'returns an OrderedCollection containing four strings: 'now', 'is','the', and 'time'.	'\<t\w+' asRegexIgnoringCase		copy: 'now is the Time'		translatingMatchesUsing: [:match | match asUppercase]returns 'now is THE TIME' (the regular expression matches wordsbeginning with either an uppercase or a lowercase T).ACKNOWLEDGEMENTSSince the first release of the matcher, thanks to the input fromseveral fellow Smalltalkers, I became convinced a native Smalltalkregular expression matcher was worth the effort to keep it alive. Forthe contributions, suggestions, and bug reports that made this release possible, I want to thank:	Felix Hack	Peter Hatch	Alan Knight	Eliot Miranda	Thomas Muhr	Robb Shecter	David N. Smith	Francis Wolinskiand anyone whom I haven't yet met or heard from, but who agrees thishas not been a complete waste of time.--Vassili BykovOctober 3, 1999"	self error: 'comment only'! !
-
-!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'lr 1/7/2010 20:10'!
-c: x syntax: xx" [You can select and `print it' examples in this method. Just don'tforget to cancel the changes.]The simplest regular expression is a single character.  It matchesexactly that character. A sequence of characters matches a string withexactly the same sequence of characters:	'a' matchesRegex: 'a'				-- true	'foobar' matchesRegex: 'foobar'		-- true	'blorple' matchesRegex: 'foobar'		-- falseThe above paragraph introduced a primitive regular expression (acharacter), and an operator (sequencing). Operators are applied toregular expressions to produce more complex regular expressions.Sequencing (placing expressions one after another) as an operator is,in a certain sense, `invisible'--yet it is arguably the most common.A more `visible' operator is Kleene closure, more often simplyreferred to as `a star'.  A regular expression followed by an asteriskmatches any number (including 0) of matches of the originalexpression. For example:	'ab' matchesRegex: 'a*b'		 		-- true	'aaaaab' matchesRegex: 'a*b'	 	-- true	'b' matchesRegex: 'a*b'		 		-- true	'aac' matchesRegex: 'a*b'	 		-- false: b does not matchA star's precedence is higher than that of sequencing. A star appliesto the shortest possible subexpression that precedes it. For example,'ab*' means `a followed by zero or more occurrences of b', not `zeroor more occurrences of ab':	'abbb' matchesRegex: 'ab*'	 		-- true	'abab' matchesRegex: 'ab*'		 	-- falseTo actually make a regex matching `zero or more occurrences of ab',`ab' is enclosed in parentheses:	'abab' matchesRegex: '(ab)*'		 	-- true	'abcab' matchesRegex: '(ab)*'	 	-- false: c spoils the funTwo other operators similar to `*' are `+' and `?'. `+' (positiveclosure, or simply `plus') matches one or more occurrences of theoriginal expression. `?' (`optional') matches zero or one, but nevermore, occurrences.	'ac' matchesRegex: 'ab*c'	 		-- true	'ac' matchesRegex: 'ab+c'	 		-- false: need at least one b	'abbc' matchesRegex: 'ab+c'		 	-- true	'abbc' matchesRegex: 'ab?c'		 	-- false: too many b'sAs we have seen, characters `*', `+', `?', `(', and `)' have specialmeaning in regular expressions. If one of them is to be usedliterally, it should be quoted: preceded with a backslash. (Thus,backslash is also special character, and needs to be quoted for aliteral match--as well as any other special character describedfurther).	'ab*' matchesRegex: 'ab*'		 	-- false: star in the right string is special	'ab*' matchesRegex: 'ab\*'	 		-- true	'a\c' matchesRegex: 'a\\c'		 	-- trueThe last operator is `|' meaning `or'. It is placed between tworegular expressions, and the resulting expression matches if one ofthe expressions matches. It has the lowest possible precedence (lowerthan sequencing). For example, `ab*|ba*' means `a followed by anynumber of b's, or b followed by any number of a's':	'abb' matchesRegex: 'ab*|ba*'	 	-- true	'baa' matchesRegex: 'ab*|ba*'	 	-- true	'baab' matchesRegex: 'ab*|ba*'	 	-- falseA bit more complex example is the following expression, matching thename of any of the Lisp-style `car', `cdr', `caar', `cadr',... functions:	c(a|d)+rIt is possible to write an expression matching an empty string, forexample: `a|'.  However, it is an error to apply `*', `+', or `?' tosuch expression: `(a|)*' is an invalid expression.So far, we have used only characters as the 'smallest' components ofregular expressions. There are other, more `interesting', components.A character set is a string of characters enclosed in squarebrackets. It matches any single character if it appears between thebrackets. For example, `[01]' matches either `0' or `1':	'0' matchesRegex: '[01]'		 		-- true	'3' matchesRegex: '[01]'		 		-- false	'11' matchesRegex: '[01]'		 		-- false: a set matches only one characterUsing plus operator, we can build the following binary numberrecognizer:	'10010100' matchesRegex: '[01]+'	 	-- true	'10001210' matchesRegex: '[01]+'	 	-- falseIf the first character after the opening bracket is `^', the set isinverted: it matches any single character *not* appearing between thebrackets:	'0' matchesRegex: '[^01]'		  		-- false	'3' matchesRegex: '[^01]'		 		-- trueFor convenience, a set may include ranges: pairs of charactersseparated with `-'. This is equivalent to listing all charactersbetween them: `[0-9]' is the same as `[0123456789]'.Special characters within a set are `^', `-', and `]' that closes theset. Below are the examples of how to literally use them in a set:	[01^]		-- put the caret anywhere except the beginning	[01-]		-- put the dash as the last character	[]01]		-- put the closing bracket as the first character 	[^]01]			(thus, empty and universal sets cannot be specified)Regular expressions can also include the following backquote escapesto refer to popular classes of characters:	\w	any word constituent character (same as [a-zA-Z0-9_])	\W	any character but a word constituent	\d	a digit (same as [0-9])	\D	anything but a digit	\s 	a whitespace character (same as [:space:] below)	\S	anything but a whitespace characterThese escapes are also allowed in character classes: '[\w+-]' means'any character that is either a word constituent, or a plus, or aminus'.Character classes can also include the following grep(1)-compatibleelements to refer to:	[:alnum:]		any alphanumeric character (same as [a-zA-Z0-9])	[:alpha:]		any alphabetic character (same as [a-zA-Z])	[:cntrl:]		any control character. (any character with code < 32)	[:digit:]		any decimal digit (same as [0-9])	[:graph:]		any graphical character. (any character with code >= 32).	[:lower:]		any lowercase character (including non-ASCII lowercase characters)	[:print:]		any printable character. In this version, this is the same as [:graph:]	[:punct:]		any punctuation character:  . , !! ? ; : ' - ( ) ` and double quotes	[:space:]		any whitespace character (space, tab, CR, LF, null, form feed, Ctrl-Z, 16r2000-16r200B, 16r3000)	[:upper:]		any uppercase character (including non-ASCII uppercase characters)	[:xdigit:]		any hexadecimal character (same as [a-fA-F0-9]).Note that many of these are only as consistent or inconsistent on issuesof locale as the underlying Smalltalk implementation. Values shown hereare for VisualWorks 7.6.Note that these elements are components of the character classes,i.e. they have to be enclosed in an extra set of square brackets toform a valid regular expression.  For example, a non-empty string ofdigits would be represented as '[[:digit:]]+'.The above primitive expressions and operators are common to manyimplementations of regular expressions. The next primitive expressionis unique to this Smalltalk implementation.A sequence of characters between colons is treated as a unary selectorwhich is supposed to be understood by Characters. A character matchessuch an expression if it answers true to a message with thatselector. This allows a more readable and efficient way of specifyingcharacter classes. For example, `[0-9]' is equivalent to `:isDigit:',but the latter is more efficient. Analogously to character sets,character classes can be negated: `:^isDigit:' matches a Characterthat answers false to #isDigit, and is therefore equivalent to`[^0-9]'.As an example, so far we have seen the following equivalent ways towrite a regular expression that matches a non-empty string of digits:	'[0-9]+'	'\d+'	'[\d]+'	'[[:digit:]]+'	:isDigit:+'The last group of special primitive expressions includes: 	.	matching any character except a NULL; 	^	matching an empty string at the beginning of a line; 	$	matching an empty string at the end of a line.	\b	an empty string at a word boundary	\B	an empty string not at a word boundary	\<	an empty string at the beginning of a word	\>	an empty string at the end of a word	'axyzb' matchesRegex: 'a.+b'		-- true	'ax zb' matchesRegex: 'a.+b'			-- true (space is matched by `.')	'axzb' matchesRegex: 'a.+b'				-- true (carriage return is matched by `.')Again, the dot ., caret ^ and dollar $ characters are special and should be quotedto be matched literally.	EXAMPLESAs the introductions said, a great use for regular expressions is userinput validation. Following are a few examples of regular expressionsthat might be handy in checking input entered by the user in an inputfield. Try them out by entering something between the quotes andprint-iting. (Also, try to imagine Smalltalk code that each validationwould require if coded by hand).  Most example expressions could havebeen written in alternative ways.Checking if aString may represent a nonnegative integer number:	'' matchesRegex: ':isDigit:+'or	'' matchesRegex: '[0-9]+'or	'' matchesRegex: '\d+'Checking if aString may represent an integer number with an optionalsign in front:	'' matchesRegex: '(\+|-)?\d+'Checking if aString is a fixed-point number, with at least one digitis required after a dot:	'' matchesRegex: '(\+|-)?\d+(\.\d+)?'The same, but allow notation like `123.':	'' matchesRegex: '(\+|-)?\d+(\.\d*)?'Recognizer for a string that might be a name: one word with firstcapital letter, no blanks, no digits.  More traditional:	'' matchesRegex: '[A-Z][A-Za-z]*'more Smalltalkish:	'' matchesRegex: ':isUppercase::isAlphabetic:*'A date in format MMM DD, YYYY with any number of spaces in between, inXX century:	'' matchesRegex: '(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[ ]+(\d\d?)[ ]*,[ ]*19(\d\d)'Note parentheses around some components of the expression above. As`Usage' section shows, they will allow us to obtain the actual stringsthat have matched them (i.e. month name, day number, and year number).For dessert, coming back to numbers: here is a recognizer for ageneral number format: anything like 999, or 999.999, or -999.999e+21.	'' matchesRegex: '(\+|-)?\d+(\.\d*)?((e|E)(\+|-)?\d+)?'"	self error: 'comment only'! !
-
-!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'vb 4/11/09 21:56'!
-d: x usage: xx" The preceding section covered the syntax of regular expressions. Itused the simplest possible interface to the matcher: sending#matchesRegex: message to the sample string, with regular expressionstring as the argument.  This section explains hairier ways of usingthe matcher.	PREFIX MATCHING AND CASE-INSENSITIVE MATCHINGA CharacterArray (an EsString in VA) also understands these messages:	#prefixMatchesRegex: regexString	#matchesRegexIgnoringCase: regexString	#prefixMatchesRegexIgnoringCase: regexString#prefixMatchesRegex: is just like #matchesRegex, except that the wholereceiver is not expected to match the regular expression passed as theargument; matching just a prefix of it is enough.  For example:	'abcde' matchesRegex: '(a|b)+'		-- false	'abcde' prefixMatchesRegex: '(a|b)+'	-- trueThe last two messages are case-insensitive versions of matching.	ENUMERATION INTERFACEAn application can be interested in all matches of a certain regularexpression within a String.  The matches are accessible using aprotocol modelled after the familiar Collection-like enumerationprotocol:	#regex: regexString matchesDo: aBlockEvaluates a one-argument <aBlock> for every match of the regularexpression within the receiver string.	#regex: regexString matchesCollect: aBlockEvaluates a one-argument <aBlock> for every match of the regularexpression within the receiver string. Collects results of evaluationsand anwers them as a SequenceableCollection.	#allRegexMatches: regexStringReturns a collection of all matches (substrings of the receiverstring) of the regular expression.  It is an equivalent of <aStringregex: regexString matchesCollect: [:each | each]>.	#allRangesOfRegexMatches: regexStringReturns a collection of all character ranges (startIndex to: stopIndex)that match the regular expression.	REPLACEMENT AND TRANSLATIONIt is possible to replace all matches of a regular expression with acertain string using the message:	#copyWithRegex: regexString matchesReplacedWith: aStringFor example:	'ab cd ab' copyWithRegex: '(a|b)+' matchesReplacedWith: 'foo'A more general substitution is match translation:	#copyWithRegex: regexString matchesTranslatedUsing: aBlockThis message evaluates a block passing it each match of the regularexpression in the receiver string and answers a copy of the receiverwith the block results spliced into it in place of the respectivematches.  For example:	'ab cd ab' copyWithRegex: '(a|b)+' matchesTranslatedUsing: [:each | each asUppercase]All messages of enumeration and replacement protocols perform acase-sensitive match.  Case-insensitive versions are not provided aspart of a CharacterArray protocol.  Instead, they are accessible usingthe lower-level matching interface.	LOWER-LEVEL INTERFACEInternally, #matchesRegex: works as follows:1. A fresh instance of RxParser is created, and the regular expressionstring is passed to it, yielding the expression's syntax tree.2. The syntax tree is passed as an initialization parameter to aninstance of RxMatcher. The instance sets up some data structure thatwill work as a recognizer for the regular expression described by thetree.3. The original string is passed to the matcher, and the matcherchecks for a match.	THE MATCHERIf you repeatedly match a number of strings against the same regularexpression using one of the messages defined in CharacterArray, theregular expression string is parsed and a matcher is created anew forevery match.  You can avoid this overhead by building a matcher forthe regular expression, and then reusing the matcher over and overagain. You can, for example, create a matcher at a class or instanceinitialization stage, and store it in a variable for future use.You can create a matcher using one of the following methods:	- Sending #forString:ignoreCase: message to RxMatcher class, withthe regular expression string and a Boolean indicating whether case isignored as arguments.	- Sending #forString: message.  It is equivalent to <... forString:regexString ignoreCase: false>.A more convenient way is using one of the two matcher-created messagesunderstood by CharacterArray.	- <regexString asRegex> is equivalent to <RxMatcher forString:regexString>.	- <regexString asRegexIgnoringCase> is equivalent to <RxMatcherforString: regexString ignoreCase: true>.Here are four examples of creating a matcher:	hexRecognizer := RxMatcher forString: '16r[0-9A-Fa-f]+'	hexRecognizer := RxMatcher forString: '16r[0-9A-Fa-f]+' ignoreCase: false	hexRecognizer := '16r[0-9A-Fa-f]+' asRegex	hexRecognizer := '16r[0-9A-F]+' asRegexIgnoringCase	MATCHINGThe matcher understands these messages (all of them return true toindicate successful match or search, and false otherwise):matches: aString	True if the whole target string (aString) matches.matchesPrefix: aString	True if some prefix of the string (not necessarily the whole	string) matches.search: aString	Search the string for the first occurrence of a matching	substring. (Note that the first two methods only try matching from	the very beginning of the string). Using the above example with a	matcher for `a+', this method would answer success given a string	`baaa', while the previous two would fail.matchesStream: aStreammatchesStreamPrefix: aStreamsearchStream: aStream	Respective analogs of the first three methods, taking input from a	stream instead of a string. The stream must be positionable and	peekable.All these methods answer a boolean indicating success. The matcheralso stores the outcome of the last match attempt and can report it:lastResult	Answers a Boolean -- the outcome of the most recent match	attempt. If no matches were attempted, the answer is unspecified.	SUBEXPRESSION MATCHESAfter a successful match attempt, you can query the specifics of whichpart of the original string has matched which part of the wholeexpression.A subexpression is a parenthesized part of a regular expression, orthe whole expression. When a regular expression is compiled, itssubexpressions are assigned indices starting from 1, depth-first,left-to-right. For example, `((ab)+(c|d))?ef' includes the followingsubexpressions with these indices:	1:	((ab)+(c|d))?ef	2:	(ab)+(c|d)	3:	ab	4:	c|dAfter a successful match, the matcher can report what part of theoriginal string matched what subexpression. It understandards thesemessages:subexpressionCount	Answers the total number of subexpressions: the highest value that	can be used as a subexpression index with this matcher. This value	is available immediately after initialization and never changes.subexpression: anIndex	An index must be a valid subexpression index, and this message	must be sent only after a successful match attempt. The method	answers a substring of the original string the corresponding	subexpression has matched to.subBeginning: anIndexsubEnd: anIndex	Answer positions within the original string or stream where the	match of a subexpression with the given index has started and	ended, respectively.This facility provides a convenient way of extracting parts of inputstrings of complex format. For example, the following piece of codeuses the 'MMM DD, YYYY' date format recognizer example from the`Syntax' section to convert a date to a three-element array with year,month, and day strings (you can select and evaluate it right here):	| matcher |	matcher := RxMatcher forString: '(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[ ]+(:isDigit::isDigit:?)[ ]*,[ ]*(19|20)(:isDigit::isDigit:)'.	(matcher matches: 'Aug 6, 1996')		ifTrue: 			[Array 				with: (matcher subexpression: 5)				with: (matcher subexpression: 2)				with: (matcher subexpression: 3)]		ifFalse: ['no match'](should answer ` #('96' 'Aug' '6')').	ENUMERATION AND REPLACEMENTThe enumeration and replacement protocols exposed in CharacterArrayare actually implemented by the matcher.  The following messages areunderstood:	#matchesIn: aString	#matchesIn: aString do: aBlock	#matchesIn: aString collect: aBlock	#copy: aString replacingMatchesWith: replacementString	#copy: aString translatingMatchesUsing: aBlock	#matchingRangesIn: aString	#matchesOnStream: aStream	#matchesOnStream: aStream do: aBlock	#matchesOnStream: aStream collect: aBlock	#copy: sourceStream to: targetStream replacingMatchesWith: replacementString	#copy: sourceStream to: targetStream translatingMatchesWith: aBlockNote that in those methods that take a block, the block may refer to the rxMatcher itself, e.g. to collect information about the position the match occurred at, or thesubexpressions of the match. An example can be seen in #matchingRangesIn:	ERROR HANDLINGException signaling objects (Signals in VisualWorks, Exceptions in VisualAge) areaccessible through RxParser class protocol. To handle possible errors, usethe protocol described below to obtain the exception objects and use theprotocol of the native Smalltalk implementation to handle them.If a syntax error is detected while parsing expression,RxParser>>syntaxErrorSignal is raised/signaled.If an error is detected while building a matcher,RxParser>>compilationErrorSignal is raised/signaled.If an error is detected while matching (for example, if a bad selectorwas specified using `:<selector>:' syntax, or because of the matcher'sinternal error), RxParser>>matchErrorSignal is raisedRxParser>>regexErrorSignal is the parent of all three.  Since any ofthe three signals can be raised within a call to #matchesRegex:, it ishandy if you want to catch them all.  For example:VisualWorks:	RxParser regexErrorSignal		handle: [:ex | ex returnWith: nil]		do: ['abc' matchesRegex: '))garbage[']VisualAge:	['abc' matchesRegex: '))garbage[']		when: RxParser regexErrorSignal		do: [:signal | signal exitWith: nil]"	self error: 'comment only'! !
-
-!RxParser class methodsFor: 'exception signaling' stamp: 'lr 11/4/2009 22:37'!
-doHandlingMessageNotUnderstood: aBlock	"MNU should be trapped and resignaled as a match error in a few places in the matcher.	This method factors out this dialect-dependent code to make porting easier."	^ aBlock		on: MessageNotUnderstood		do: [:ex | RxParser signalMatchException: 'invalid predicate selector']! !
-
-!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'vb 4/11/09 21:56'!
-e: x implementationNotes: xx"		Version:		1.1	Released:		October 1999	Mail to:		Vassili Bykov <vassili@parcplace.com>, <v_bykov@yahoo.com>	Flames to:		/dev/null	WHAT IS ADDEDThe matcher includes classes in two categories:	VB-Regex-Syntax	VB-Regex-Matcherand a few CharacterArray methods in `VB-regex' protocol.  No systemclasses or methods are modified.	WHAT TO LOOK AT FIRSTString>>matchesRegex: -- in 90% cases this method is all you need toaccess the package.RxParser -- accepts a string or a stream of characters with a regularexpression, and produces a syntax tree corresponding to theexpression. The tree is made of instances of Rxs<whatever> classes.RxMatcher -- accepts a syntax tree of a regular expression built bythe parser and compiles it into a matcher: a structure made ofinstances of Rxm<whatever> classes. The RxMatcher instance can testwhether a string or a positionable stream of characters matches theoriginal regular expression, or search a string or a stream forsubstrings matching the expression. After a match is found, thematcher can report a specific string that matched the wholeexpression, or any parenthesized subexpression of it.All other classes support the above functionality and are used byRxParser, RxMatcher, or both.	CAVEATSThe matcher is similar in spirit, but NOT in the design--let alone thecode--to the original Henry Spencer's regular expressionimplementation in C.  The focus is on simplicity, not on efficiency.I didn't optimize or profile anything.  I may in future--or I may not:I do this in my spare time and I don't promise anything.The matcher passes H. Spencer's test suite (see 'test suite'protocol), with quite a few extra tests added, so chances are goodthere are not too many bugs.  But watch out anyway.	EXTENSIONS, FUTURE, ETC.With the existing separation between the parser, the syntax tree, andthe matcher, it is easy to extend the system with other matchers basedon other algorithms. In fact, I have a DFA-based matcher right now,but I don't feel it is good enough to include it here.  I might addautomata-based matchers later, but again I don't promise anything.	HOW TO REACH MEAs of today (December 20, 2000), you can contact me at<vassili@parcplace.com>. If this doesn't work, look aroundcomp.lang.smalltalk or comp.lang.lisp.  "	self error: 'comment only'! !
-
-!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'vb 4/11/09 21:56'!
-f: x boringStuff: xx"The Regular Expression Matcher (``The Software'') is Copyright (C) 1996, 1999 Vassili Bykov.  It is provided to the Smalltalk community in hope it will be useful.1. This license applies to the package as a whole, as well as to any   component of it. By performing any of the activities described   below, you accept the terms of this agreement.2. The software is provided free of charge, and ``as is'', in hope   that it will be useful, with ABSOLUTELY NO WARRANTY. The entire   risk and all responsibility for the use of the software is with   you.  Under no circumstances the author may be held responsible for   loss of data, loss of profit, or any other damage resulting   directly or indirectly from the use of the software, even if the   damage is caused by defects in the software.3. You may use this software in any applications you build.4. You may distribute this software provided that the software   documentation and copyright notices are included and intact.5. You may create and distribute modified versions of the software,   such as ports to other Smalltalk dialects or derived work, provided   that:    a. any modified version is expressly marked as such and is not   misrepresented as the original software;    b. credit is given to the original software in the source code and   documentation of the derived work;    c. the copyright notice at the top of this document accompanies   copyright notices of any modified version.  "	self error: 'comment only'! !
-
-!RxParser class methodsFor: 'class initialization' stamp: 'avi 11/30/2003 13:26'!
-initialize	"self initialize"	self		initializeBackslashConstants;		initializeBackslashSpecials! !
-
-!RxParser class methodsFor: 'class initialization' stamp: 'lr 11/4/2009 22:14'!
-initializeBackslashConstants	"self initializeBackslashConstants"	(BackslashConstants := Dictionary new)		at: $e put: Character escape;		at: $n put: Character lf;		at: $r put: Character cr;		at: $f put: Character newPage;		at: $t put: Character tab! !
-
-!RxParser class methodsFor: 'class initialization' stamp: 'vb 4/11/09 21:56'!
-initializeBackslashSpecials	"Keys are characters that normally follow a \, the values are	associations of classes and initialization selectors on the instance side	of the classes."	"self initializeBackslashSpecials"	(BackslashSpecials := Dictionary new)		at: $w put: (Association key: RxsPredicate value: #beWordConstituent);		at: $W put: (Association key: RxsPredicate value: #beNotWordConstituent);		at: $s put: (Association key: RxsPredicate value: #beSpace);		at: $S put: (Association key: RxsPredicate value: #beNotSpace);		at: $d put: (Association key: RxsPredicate value: #beDigit);		at: $D put: (Association key: RxsPredicate value: #beNotDigit);		at: $b put: (Association key: RxsContextCondition value: #beWordBoundary);		at: $B put: (Association key: RxsContextCondition value: #beNonWordBoundary);		at: $< put: (Association key: RxsContextCondition value: #beBeginningOfWord);		at: $> put: (Association key: RxsContextCondition value: #beEndOfWord)! !
-
-!RxParser class methodsFor: 'utilities' stamp: 'vb 4/11/09 21:56'!
-parse: aString	"Parse the argument and return the result (the parse tree).	In case of a syntax error, the corresponding exception is signaled."	^self new parse: aString! !
-
-!RxParser class methodsFor: 'preferences' stamp: 'vb 4/11/09 21:56'!
-preferredMatcherClass	"The matcher to use. For now just one is available, but in	principle this determines the matchers built implicitly,	such as by String>>asRegex, or String>>matchesRegex:.	This might seem a bit strange place for this preference, but	Parser is still more or less `central' thing in the whole package."	^RxMatcher! !
-
-!RxParser class methodsFor: 'utilities' stamp: 'avi 11/30/2003 13:23'!
-safelyParse: aString	"Parse the argument and return the result (the parse tree).	In case of a syntax error, return nil.	Exception handling here is dialect-dependent."	^ [self new parse: aString] on: RegexSyntaxError do: [:ex | nil]! !
-
-!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
-signalCompilationException: errorString	RegexCompilationError new signal: errorString! !
-
-!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
-signalMatchException: errorString	RegexMatchingError new signal: errorString! !
-
-!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
-signalSyntaxException: errorString	RegexSyntaxError new signal: errorString! !
-
-!RxmBranch methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-alternative: aBranch	"See class comment for instance variable description."	alternative := aBranch! !
-
-!RxmBranch methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beLoopback	"See class comment for instance variable description."	loopback := true! !
-
-!RxmBranch methodsFor: 'initialize-release' stamp: 'lr 11/4/2009 22:38'!
-initialize	"See class comment for instance variable description."	super initialize.	loopback := false! !
-
-!RxmBranch methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
-matchAgainst: aMatcher	"Match either `next' or `alternative'. Fail if the alternative is nil."	^(next matchAgainst: aMatcher)		or: [alternative notNil			and: [alternative matchAgainst: aMatcher]]! !
-
-!RxmBranch methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
-pointTailTo: aNode	"See superclass for explanations."	loopback		ifTrue: [alternative == nil			ifTrue: [alternative := aNode]			ifFalse: [alternative pointTailTo: aNode]]		ifFalse: [super pointTailTo: aNode]! !
-
-!RxmBranch methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
-terminateWith: aNode	"See superclass for explanations."	loopback		ifTrue: [alternative == nil			ifTrue: [alternative := aNode]			ifFalse: [alternative terminateWith: aNode]]		ifFalse: [super terminateWith: aNode]! !
-
-!RxmLink methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
-matchAgainst: aMatcher	"If a link does not match the contents of the matcher's stream,	answer false. Otherwise, let the next matcher in the chain match."	^next matchAgainst: aMatcher! !
-
-!RxmLink methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
-next		^next! !
-
-!RxmLink methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-next: aLink	"Set the next link, either an RxmLink or an RxmTerminator."	next := aLink! !
-
-!RxmLink methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
-pointTailTo: anRxmLink	"Propagate this message along the chain of links.	Point `next' reference of the last link to <anRxmLink>.	If the chain is already terminated, blow up."	next == nil		ifTrue: [next := anRxmLink]		ifFalse: [next pointTailTo: anRxmLink]! !
-
-!RxmLink methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
-terminateWith: aTerminator	"Propagate this message along the chain of links, and	make aTerminator the `next' link of the last link in the chain.	If the chain is already reminated with the same terminator, 	do not blow up."	next == nil		ifTrue: [next := aTerminator]		ifFalse: [next terminateWith: aTerminator]! !
-
-!RxmMarker methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-index: anIndex	"An index is a key that makes sense for the matcher.	This key can be passed to marker position getters and	setters to access position for this marker in the current	matching session."	index := anIndex! !
-
-!RxmMarker methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
-matchAgainst: aMatcher	"If the rest of the link chain matches successfully, report the	position of the stream *before* the match started to the matcher."	| startPosition |	startPosition := aMatcher position.	(next matchAgainst: aMatcher)		ifTrue:			[aMatcher markerPositionAt: index add: startPosition.			^true].	^false! !
-
-!RxmPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-bePerform: aSelector	"Match any single character that answers true  to this message."	self predicate: 		[:char | 		RxParser doHandlingMessageNotUnderstood: [char perform: aSelector]]! !
-
-!RxmPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-bePerformNot: aSelector	"Match any single character that answers false to this message."	self predicate: 		[:char | 		RxParser doHandlingMessageNotUnderstood: [(char perform: aSelector) not]]! !
-
-!RxmPredicate methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
-matchAgainst: aMatcher	"Match if the predicate block evaluates to true when given the	current stream character as the argument."	| original |	original := aMatcher currentState.	(aMatcher atEnd not 		and: [(predicate value: aMatcher next)			and: [next matchAgainst: aMatcher]])		ifTrue: [^true]		ifFalse:			[aMatcher restoreState: original.			^false]! !
-
-!RxmPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-predicate: aBlock	"This link will match any single character for which <aBlock>	evaluates to true."	aBlock numArgs ~= 1 ifTrue: [self error: 'bad predicate block'].	predicate := aBlock.	^self! !
-
-!RxmPredicate class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
-with: unaryBlock	^self new predicate: unaryBlock! !
-
-!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beBeginningOfLine	matchSelector := #atBeginningOfLine! !
-
-!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beBeginningOfWord	matchSelector := #atBeginningOfWord! !
-
-!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beEndOfLine	matchSelector := #atEndOfLine! !
-
-!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beEndOfWord	matchSelector := #atEndOfWord! !
-
-!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beNotWordBoundary	matchSelector := #notAtWordBoundary! !
-
-!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beWordBoundary	matchSelector := #atWordBoundary! !
-
-!RxmSpecial methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
-matchAgainst: aMatcher	"Match without consuming any input, if the matcher is	in appropriate state."	^(aMatcher perform: matchSelector)		and: [next matchAgainst: aMatcher]! !
-
-!RxmSubstring methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beCaseInsensitive	compare := [:char1 :char2 | char1 sameAs: char2]! !
-
-!RxmSubstring methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beCaseSensitive	compare := [:char1 :char2 | char1 = char2]! !
-
-!RxmSubstring methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-character: aCharacter ignoreCase: aBoolean	"Match exactly this character."	sample := String with: aCharacter.	aBoolean ifTrue: [self beCaseInsensitive]! !
-
-!RxmSubstring methodsFor: 'initialize-release' stamp: 'lr 11/4/2009 22:38'!
-initialize	super initialize.	self beCaseSensitive! !
-
-!RxmSubstring methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
-matchAgainst: aMatcher	"Match if my sample stream is exactly the current prefix	of the matcher stream's contents."	| originalState sampleStream mismatch |	originalState := aMatcher currentState.	sampleStream := self sampleStream.	mismatch := false.	[sampleStream atEnd		or: [aMatcher atEnd		or: [mismatch := (compare value: sampleStream next value: aMatcher next) not]]] whileFalse.	(mismatch not and: [sampleStream atEnd and: [next matchAgainst: aMatcher]])		ifTrue: [^true]		ifFalse: 			[aMatcher restoreState: originalState.			^false]! !
-
-!RxmSubstring methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-sampleStream	^sample readStream! !
-
-!RxmSubstring methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-substring: aString ignoreCase: aBoolean	"Match exactly this string."	sample := aString.	aBoolean ifTrue: [self beCaseInsensitive]! !
-
-!RxmTerminator methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
-matchAgainst: aStream	"If got here, the match is successful."	^true! !
-
-!RxmTerminator methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
-pointTailTo: anRxmLink	"Branch tails are never redirected by the build algorithm.	Healthy terminators should never receive this."	RxParser signalCompilationException:		'internal matcher build error - redirecting terminator tail'! !
-
-!RxmTerminator methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
-terminateWith: aTerminator	"Branch terminators are never supposed to change.	Make sure this is the case."	aTerminator ~~ self		ifTrue: [RxParser signalCompilationException:				'internal matcher build error - wrong terminator']! !
-
-!RxsBranch methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-branch	^branch! !
-
-!RxsBranch methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-dispatchTo: aMatcher	"Inform the matcher of the kind of the node, and it	will do whatever it has to."	^aMatcher syntaxBranch: self! !
-
-!RxsBranch methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializePiece: aPiece branch: aBranch	"See class comment for instance variables description."	piece := aPiece.	branch := aBranch! !
-
-!RxsBranch methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isNullable	^piece isNullable and: [branch isNil or: [branch isNullable]]! !
-
-!RxsBranch methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-piece	^piece! !
-
-!RxsBranch methodsFor: 'optimization' stamp: 'vb 4/11/09 21:56'!
-tryMergingInto: aStream	"Concatenation of a few simple characters can be optimized	to be a plain substring match. Answer the node to resume	syntax tree traversal at. Epsilon node used to terminate the branch	will implement this to answer nil, thus indicating that the branch	has ended."	piece isAtomic ifFalse: [^self].	aStream nextPut: piece character.	^branch isNil		ifTrue: [branch]		ifFalse: [branch tryMergingInto: aStream]! !
-
-!RxsCharSet methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-dispatchTo: aMatcher	"Inform the matcher of the kind of the node, and it	will do whatever it has to."	^aMatcher syntaxCharSet: self! !
-
-!RxsCharSet methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
-enumerablePartPredicateIgnoringCase: aBoolean	| enumeration |	enumeration := self optimalSetIgnoringCase: aBoolean.	^negated		ifTrue: [[:char | (enumeration includes: char) not]]		ifFalse: [[:char | enumeration includes: char]]! !
-
-!RxsCharSet methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
-enumerableSetIgnoringCase: aBoolean	"Answer a collection of characters that make up the portion of me	that can be enumerated."	| set |	set := Set new.	elements do:		[:each |		each isEnumerable ifTrue:			[each enumerateTo: set ignoringCase: aBoolean]].	^set! !
-
-!RxsCharSet methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-hasPredicates	^elements contains: [:some | some isEnumerable not]! !
-
-!RxsCharSet methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializeElements: aCollection negated: aBoolean	"See class comment for instance variables description."	elements := aCollection.	negated := aBoolean! !
-
-!RxsCharSet methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isEnumerable	elements detect: [:some | some isEnumerable not] ifNone: [^true].	^false! !
-
-!RxsCharSet methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isNegated	^negated! !
-
-!RxsCharSet methodsFor: 'privileged' stamp: 'lr 11/4/2009 22:27'!
-optimalSetIgnoringCase: aBoolean	"Assuming the client with search the `set' using #includes:,	answer a collection with the contents of `set', of the class	that will provide the fastest lookup. Strings are faster than	Sets for short strings."	| set |	set := self enumerableSetIgnoringCase: aBoolean.	^set size < 10		ifTrue: [set asArray]		ifFalse: [set]! !
-
-!RxsCharSet methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-predicateIgnoringCase: aBoolean	| predicate enumerable |	enumerable := self enumerablePartPredicateIgnoringCase: aBoolean.	^self hasPredicates		ifFalse: [enumerable]		ifTrue:			[predicate := self predicatePartPredicate.			negated				ifTrue: [[:char | (enumerable value: char) and: [predicate value: char]]]				ifFalse: [[:char | (enumerable value: char) or: [predicate value: char]]]]! !
-
-!RxsCharSet methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
-predicatePartPredicate	"Answer a predicate that tests all of my elements that cannot be	enumerated."	| predicates |	predicates := elements reject: [:some | some isEnumerable].	predicates isEmpty		ifTrue: [^[:char | negated]].	predicates size = 1		ifTrue: [^negated			ifTrue: [predicates first predicateNegation]			ifFalse: [predicates first predicate]].	predicates := predicates collect: [:each | each predicate].	^negated		ifFalse:			[[:char | predicates contains: [:some | some value: char]]]		ifTrue:			[[:char | (predicates contains: [:some | some value: char]) not]]! !
-
-!RxsCharSet methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-predicates	^(elements reject: [:some | some isEnumerable])		collect: [:each | each predicate]! !
-
-!RxsCharacter methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-character	^character! !
-
-!RxsCharacter methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-dispatchTo: aMatcher	"Inform the matcher of the kind of the node, and it	will do whatever it has to."	^aMatcher syntaxCharacter: self! !
-
-!RxsCharacter methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-enumerateTo: aSet ignoringCase: aBoolean	aBoolean		ifTrue: 			[aSet 				add: character asUppercase;				add: character asLowercase]		ifFalse: [aSet add: character]! !
-
-!RxsCharacter methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializeCharacter: aCharacter	"See class comment for instance variable description."	character := aCharacter! !
-
-!RxsCharacter methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isAtomic	"A character is always atomic."	^true! !
-
-!RxsCharacter methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isEnumerable	^true! !
-
-!RxsCharacter methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isNullable	^false! !
-
-!RxsCharacter class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
-with: aCharacter	^self new initializeCharacter: aCharacter! !
-
-!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beAny	"Matches anything but a newline."	kind := #syntaxAny! !
-
-!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beBeginningOfLine	"Matches empty string at the beginning of a line."	kind := #syntaxBeginningOfLine! !
-
-!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beBeginningOfWord	"Matches empty string at the beginning of a word."	kind := #syntaxBeginningOfWord! !
-
-!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beEndOfLine	"Matches empty string at the end of a line."	kind := #syntaxEndOfLine! !
-
-!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beEndOfWord	"Matches empty string at the end of a word."	kind := #syntaxEndOfWord! !
-
-!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beNonWordBoundary	"Analog of \B."	kind := #syntaxNonWordBoundary! !
-
-!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beWordBoundary	"Analog of \w (alphanumeric plus _)."	kind := #syntaxWordBoundary! !
-
-!RxsContextCondition methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-dispatchTo: aBuilder	^aBuilder perform: kind! !
-
-!RxsContextCondition methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isNullable	^#syntaxAny ~~ kind! !
-
-!RxsEpsilon methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
-dispatchTo: aBuilder	"Inform the matcher of the kind of the node, and it	will do whatever it has to."	^aBuilder syntaxEpsilon! !
-
-!RxsEpsilon methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isNullable	"See comment in the superclass."	^true! !
-
-!RxsMessagePredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-dispatchTo: aBuilder	"Inform the matcher of the kind of the node, and it	will do whatever it has to."	^aBuilder syntaxMessagePredicate: self! !
-
-!RxsMessagePredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializeSelector: aSelector	"The selector must be a one-argument message understood by Character."	selector := aSelector! !
-
-!RxsMessagePredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializeSelector: aSelector negated: aBoolean	"The selector must be a one-argument message understood by Character."	selector := aSelector.	negated := aBoolean! !
-
-!RxsMessagePredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-negated	^negated! !
-
-!RxsMessagePredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-selector	^selector! !
-
-!RxsNode methodsFor: 'constants' stamp: 'vb 4/11/09 21:56'!
-indentCharacter	"Normally, #printOn:withIndent: method in subclasses	print several characters returned by this method to indicate	the tree structure."	^$+! !
-
-!RxsNode methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isAtomic	"Answer whether the node is atomic, i.e. matches exactly one 	constant predefined normal character.  A matcher may decide to 	optimize matching of a sequence of atomic nodes by glueing them 	together in a string."	^false "tentatively"! !
-
-!RxsNode methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isNullable	"True if the node can match an empty sequence of characters."	^false "for most nodes"! !
-
-!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-atom	^atom! !
-
-!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-character	"If this node is atomic, answer the character it	represents. It is the caller's responsibility to make sure this	node is indeed atomic before using this."	^atom character! !
-
-!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-dispatchTo: aMatcher	"Inform the matcher of the kind of the node, and it	will do whatever it has to."	^aMatcher syntaxPiece: self! !
-
-!RxsPiece methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializeAtom: anAtom	"This piece is exactly one occurrence of the specified RxsAtom."	self initializeAtom: anAtom min: 1 max: 1! !
-
-!RxsPiece methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializeAtom: anAtom min: minOccurrences max: maxOccurrences	"This piece is from <minOccurrences> to <maxOccurrences> 	occurrences of the specified RxsAtom."	atom := anAtom.	min := minOccurrences.	max := maxOccurrences! !
-
-!RxsPiece methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializeOptionalAtom: anAtom	"This piece is 0 or 1 occurrences of the specified RxsAtom."	self initializeAtom: anAtom min: 0 max: 1! !
-
-!RxsPiece methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializePlusAtom: anAtom	"This piece is one or more occurrences of the specified RxsAtom."	self initializeAtom: anAtom min: 1 max: nil! !
-
-!RxsPiece methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializeStarAtom: anAtom	"This piece is any number of occurrences of the atom."	self initializeAtom: anAtom min: 0 max: nil! !
-
-!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isAtomic	"A piece is atomic if only it contains exactly one atom	which is atomic (sic)."	^self isSingular and: [atom isAtomic]! !
-
-!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isNullable	"A piece is nullable if it allows 0 matches. 	This is often handy to know for optimization."	^min = 0 or: [atom isNullable]! !
-
-!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isOptional	^min = 0 and: [max = 1]! !
-
-!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isPlus	^min = 1 and: [max == nil]! !
-
-!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isSingular	"A piece with a range is 1 to 1 needs can be compiled	as a simple match."	^min = 1 and: [max = 1]! !
-
-!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isStar	^min = 0 and: [max == nil]! !
-
-!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-max	"The value answered may be nil, indicating infinity."	^max! !
-
-!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-min	^min! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beAlphaNumeric	predicate := [:char | char isAlphaNumeric].	negation := [:char | char isAlphaNumeric not]! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'lr 11/4/2009 22:29'!
-beAlphabetic	predicate := [:char | char isLetter].	negation := [:char | char isLetter not]! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beBackslash	predicate := [:char | char == $\].	negation := [:char | char ~~ $\]! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beControl	predicate := [:char | char asInteger < 32].	negation := [:char | char asInteger >= 32]! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beDigit	predicate := [:char | char isDigit].	negation := [:char | char isDigit not]! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beGraphics	self		beControl;		negate! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beHexDigit	| hexLetters |	hexLetters := 'abcdefABCDEF'.	predicate := [:char | char isDigit or: [hexLetters includes: char]].	negation := [:char | char isDigit not and: [(hexLetters includes: char) not]]! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beLowercase	predicate := [:char | char isLowercase].	negation := [:char | char isLowercase not]! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beNotDigit	self		beDigit;		negate! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beNotSpace	self		beSpace;		negate! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beNotWordConstituent	self		beWordConstituent;		negate! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-bePrintable	self		beControl;		negate! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-bePunctuation	| punctuationChars |	punctuationChars := #($. $, $!! $? $; $: $" $' $- $( $) $`).	predicate := [:char | punctuationChars includes: char].	negation := [:char | (punctuationChars includes: char) not]! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beSpace	predicate := [:char | char isSeparator].	negation := [:char | char isSeparator not]! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-beUppercase	predicate := [:char | char isUppercase].	negation := [:char | char isUppercase not]! !
-
-!RxsPredicate methodsFor: 'initialize-release' stamp: 'lr 1/7/2010 20:06'!
-beWordConstituent	predicate := [:char | char isAlphaNumeric or: [char == $_]].	negation := [:char | char isAlphaNumeric not and: [char ~~ $_]]! !
-
-!RxsPredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-dispatchTo: anObject	^anObject syntaxPredicate: self! !
-
-!RxsPredicate methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isAtomic	"A predicate is a single character but the character is not known in advance."	^false! !
-
-!RxsPredicate methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isEnumerable	^false! !
-
-!RxsPredicate methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
-negate	| tmp |	tmp := predicate.	predicate := negation.	negation := tmp! !
-
-!RxsPredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-negated	^self copy negate! !
-
-!RxsPredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-predicate	^predicate! !
-
-!RxsPredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-predicateNegation	^negation! !
-
-!RxsPredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-value: aCharacter	^predicate value: aCharacter! !
-
-!RxsPredicate class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
-forEscapedLetter: aCharacter	^self new perform:		(EscapedLetterSelectors			at: aCharacter			ifAbsent: [RxParser signalSyntaxException: 'bad backslash escape'])! !
-
-!RxsPredicate class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
-forNamedClass: aString	^self new perform:		(NamedClassSelectors			at: aString			ifAbsent: [RxParser signalSyntaxException: 'bad character class name'])! !
-
-!RxsPredicate class methodsFor: 'class initialization' stamp: 'vb 4/11/09 21:56'!
-initialize	"self initialize"	self		initializeNamedClassSelectors;		initializeEscapedLetterSelectors! !
-
-!RxsPredicate class methodsFor: 'class initialization' stamp: 'vb 4/11/09 21:56'!
-initializeEscapedLetterSelectors	"self initializeEscapedLetterSelectors"	(EscapedLetterSelectors := Dictionary new)		at: $w put: #beWordConstituent;		at: $W put: #beNotWordConstituent;		at: $d put: #beDigit;		at: $D put: #beNotDigit;		at: $s put: #beSpace;		at: $S put: #beNotSpace;		at: $\ put: #beBackslash! !
-
-!RxsPredicate class methodsFor: 'class initialization' stamp: 'vb 4/11/09 21:56'!
-initializeNamedClassSelectors	"self initializeNamedClassSelectors"	(NamedClassSelectors := Dictionary new)		at: 'alnum' put: #beAlphaNumeric;		at: 'alpha' put: #beAlphabetic;		at: 'cntrl' put: #beControl;		at: 'digit' put: #beDigit;		at: 'graph' put: #beGraphics;		at: 'lower' put: #beLowercase;		at: 'print' put: #bePrintable;		at: 'punct' put: #bePunctuation;		at: 'space' put: #beSpace;		at: 'upper' put: #beUppercase;		at: 'xdigit' put: #beHexDigit! !
-
-!RxsRange methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-enumerateTo: aSet ignoringCase: aBoolean	"Add all of the elements I represent to the collection."	first asInteger to: last asInteger do:		[:charCode | | character |		character := charCode asCharacter.		aBoolean		ifTrue: 			[aSet 				add: character asUppercase;				add: character asLowercase]		ifFalse: [aSet add: character]]! !
-
-!RxsRange methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializeFirst: aCharacter last: anotherCharacter	first := aCharacter.	last := anotherCharacter! !
-
-!RxsRange methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isEnumerable	^true! !
-
-!RxsRange class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
-from: aCharacter to: anotherCharacter	^self new initializeFirst: aCharacter last: anotherCharacter! !
-
-!RxsRegex methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-branch	^branch! !
-
-!RxsRegex methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-dispatchTo: aMatcher	"Inform the matcher of the kind of the node, and it	will do whatever it has to."	^aMatcher syntaxRegex: self! !
-
-!RxsRegex methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
-initializeBranch: aBranch regex: aRegex	"See class comment for instance variable description."	branch := aBranch.	regex := aRegex! !
-
-!RxsRegex methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
-isNullable	^branch isNullable or: [regex notNil and: [regex isNullable]]! !
-
-!RxsRegex methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
-regex	^regex! !
+-- Regular Expression Matcher v 1.1 (C) 1996, 1999 Vassili Bykov
+--
+The body of a parenthesized thing, or a top-level expression, also an atom.  
+
+Instance variables:
+	branch		<RxsBranch>
+	regex		<RxsRegex | RxsEpsilon>!
 
 !String methodsFor: '*Regex-Core' stamp: 'gsa 12/20/2012 10:31'!
 allRangesOfRegexMatches: rxString
@@ -1238,6 +575,3162 @@ regex: rxString matchesDo: aBlock
 search: aString
 	"compatibility method to make regexp and strings work polymorphicly"
 	^ aString includesSubString: self! !
+
+!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
+addChar: aChar
+
+	elements add: (RxsCharacter with: aChar)! !
+
+!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
+addRangeFrom: firstChar to: lastChar
+
+	firstChar asInteger > lastChar asInteger ifTrue:
+		[RxParser signalSyntaxException: ' bad character range'].
+	elements add: (RxsRange from: firstChar to: lastChar)! !
+
+!RxCharSetParser methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initialize: aStream
+
+	source := aStream.
+	lookahead := aStream next.
+	elements := OrderedCollection new! !
+
+!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
+match: aCharacter
+
+	aCharacter = lookahead
+		ifFalse: [RxParser signalSyntaxException: 'unexpected character: ', (String with: lookahead)].
+	^source atEnd
+		ifTrue: [lookahead := nil]
+		ifFalse: [lookahead := source next]! !
+
+!RxCharSetParser methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+parse
+
+	lookahead = $- ifTrue:
+		[self addChar: $-.
+		self match: $-].
+	[lookahead isNil] whileFalse: [self parseStep].
+	^elements! !
+
+!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
+parseCharOrRange
+
+	| firstChar |
+	firstChar := lookahead.
+	self match: firstChar.
+	lookahead = $- ifTrue:
+		[self match: $-.
+		lookahead isNil
+			ifTrue: [^self addChar: firstChar; addChar: $-]
+			ifFalse: 
+				[self addRangeFrom: firstChar to: lookahead.
+				^self match: lookahead]].
+	self addChar: firstChar! !
+
+!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
+parseEscapeChar
+
+	self match: $\.
+	$- = lookahead
+		ifTrue: [elements add: (RxsCharacter with: $-)]
+		ifFalse: [elements add: (RxsPredicate forEscapedLetter: lookahead)].
+	self match: lookahead! !
+
+!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
+parseNamedSet
+
+	| name |
+	self match: $[; match: $:.
+	name := (String with: lookahead), (source upTo: $:).
+	lookahead := source next.
+	self match: $].
+	elements add: (RxsPredicate forNamedClass: name)! !
+
+!RxCharSetParser methodsFor: 'parsing' stamp: 'vb 4/11/09 21:56'!
+parseStep
+
+	lookahead = $[ ifTrue:
+		[source peek = $:
+			ifTrue: [^self parseNamedSet]
+			ifFalse: [^self parseCharOrRange]].
+	lookahead = $\ ifTrue:
+		[^self parseEscapeChar].
+	lookahead = $- ifTrue:
+		[RxParser signalSyntaxException: 'invalid range'].
+	self parseCharOrRange! !
+
+!RxCharSetParser class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
+on: aStream
+
+	^self new initialize: aStream! !
+
+!RxMatchOptimizer methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+canStartMatch: aCharacter in: aMatcher 
+	"Answer whether a match could commence at the given lookahead
+	character, or in the current state of <aMatcher>. True answered
+	by this method does not mean a match will definitly occur, while false
+	answered by this method *does* guarantee a match will never occur."
+
+	aCharacter isNil ifTrue: [^true].
+	^testBlock == nil or: [testBlock value: aCharacter value: aMatcher]! !
+
+!RxMatchOptimizer methodsFor: 'accessing' stamp: 'KenD 11/22/2016 13:08:58'!
+conditionTester
+	"#any condition is filtered at the higher level;
+	it cannot appear among the conditions here."
+
+	| matchCondition |
+	conditions isEmpty ifTrue: [^nil].
+	conditions size = 1 ifTrue:
+		[matchCondition := conditions detect: [:ignored | true].
+		"Special case all of the possible conditions."
+		#atBeginningOfLine = matchCondition ifTrue: [^[:c :matcher | matcher atBeginningOfLine]].
+		#atEndOfLine = matchCondition ifTrue: [^[:c :matcher | matcher atEndOfLine]].
+		#atBeginningOfWord = matchCondition ifTrue: [^[:c :matcher | matcher atBeginningOfWord]].
+		#atEndOfWord = matchCondition ifTrue: [^[:c :matcher | matcher atEndOfWord]].
+		#atWordBoundary = matchCondition ifTrue: [^[:c :matcher | matcher atWordBoundary]].
+		#notAtWordBoundary = matchCondition ifTrue: [^[:c :matcher | matcher notAtWordBoundary]].
+		RxParser signalCompilationException: 'invalid match condition'].
+	"More than one condition. Capture them as an array in scope."
+	matchCondition := conditions asArray.
+	^[:c :matcher |
+		matchCondition includes:
+			[:conditionSelector |
+			matcher perform: conditionSelector]]! !
+
+!RxMatchOptimizer methodsFor: 'private' stamp: 'KenD 11/22/2016 13:09:05'!
+determineTestMethod
+	"Answer a block closure that will work as a can-match predicate.
+	Answer nil if no viable optimization is possible (too many chars would
+	be able to start a match)."
+
+	| testers |
+	(conditions includes: #any) ifTrue: [^nil].
+	testers := OrderedCollection new: 5.
+	#(#prefixTester #nonPrefixTester #conditionTester #methodPredicateTester #nonMethodPredicateTester #predicateTester #nonPredicateTester)
+		do: 
+			[:selector | 
+			| tester |
+			tester := self perform: selector.
+			tester notNil ifTrue: [testers add: tester]].
+	testers isEmpty ifTrue: [^nil].
+	testers size = 1 ifTrue: [^testers first].
+	testers := testers asArray.
+	^[:char :matcher | testers includes: [:t | t value: char value: matcher]]! !
+
+!RxMatchOptimizer methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initialize: aRegex ignoreCase: aBoolean 
+	"Set `testMethod' variable to a can-match predicate block:
+	two-argument block which accepts a lookahead character
+	and a matcher (presumably built from aRegex) and answers 
+	a boolean indicating whether a match could start at the given
+	lookahead. "
+
+	ignoreCase := aBoolean.
+	prefixes := Set new: 10.
+	nonPrefixes := Set new: 10.
+	conditions := Set new: 3.
+	methodPredicates := Set new: 3.
+	nonMethodPredicates := Set new: 3.
+	predicates := Set new: 3.
+	nonPredicates := Set new: 3.
+	aRegex dispatchTo: self.	"If the whole expression is nullable, 
+		end-of-line is an implicit can-match condition!!"
+	aRegex isNullable ifTrue: [conditions add: #atEndOfLine].
+	testBlock := self determineTestMethod! !
+
+!RxMatchOptimizer methodsFor: 'accessing' stamp: 'KenD 11/22/2016 13:09:10'!
+methodPredicateTester
+	| p selector |
+	methodPredicates isEmpty ifTrue: [^nil].
+	p := self optimizeSet: methodPredicates.	"also allows copying closures"
+	^p size = 1
+		ifTrue: 
+			["might be a pretty common case"
+			selector := p first.
+			[:char :matcher | 
+			RxParser doHandlingMessageNotUnderstood:
+				[char perform: selector]]]
+		ifFalse: 
+			[[:char :m | 
+			RxParser doHandlingMessageNotUnderstood:
+				[p includes: [:sel | char perform: sel]]]]! !
+
+!RxMatchOptimizer methodsFor: 'accessing' stamp: 'KenD 11/22/2016 13:09:15'!
+nonMethodPredicateTester
+	| p selector |
+	nonMethodPredicates isEmpty ifTrue: [^nil].
+	p := self optimizeSet: nonMethodPredicates.	"also allows copying closures"
+	^p size = 1
+		ifTrue: 
+			[selector := p first.
+			[:char :matcher | 
+			RxParser doHandlingMessageNotUnderstood:
+				[(char perform: selector) not]]]
+		ifFalse: 
+			[[:char :m | 
+			RxParser doHandlingMessageNotUnderstood:
+				[p includes: [:sel | (char perform: sel) not]]]]! !
+
+!RxMatchOptimizer methodsFor: 'private' stamp: 'KenD 11/22/2016 13:09:20'!
+nonPredicateTester
+
+	| p pred |
+	nonPredicates isEmpty ifTrue: [^nil].
+	p := self optimizeSet: nonPredicates.	"also allows copying closures"
+	^p size = 1
+		ifTrue: 
+			[pred := p first.
+			[:char :matcher | (pred value: char) not]]
+		ifFalse: 
+			[[:char :m | p includes: [:some | (some value: char) not]]]! !
+
+!RxMatchOptimizer methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+nonPrefixTester
+
+	| np nonPrefixChar |
+	nonPrefixes isEmpty ifTrue: [^nil].
+	np := self optimizeSet: nonPrefixes. "also allows copying closures"
+	^np size = 1 "might be be pretty common case"
+		ifTrue: 
+			[nonPrefixChar := np first.
+			[:char :matcher | char ~= nonPrefixChar]]
+		ifFalse: [[:char : matcher | (np includes: char) not]]! !
+
+!RxMatchOptimizer methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+optimizeSet: aSet
+	"If a set is small, convert it to array to speed up lookup
+	(Array has no hashing overhead, beats Set on small number
+	of elements)."
+
+	^aSet size < 10 ifTrue: [aSet asArray] ifFalse: [aSet]! !
+
+!RxMatchOptimizer methodsFor: 'private' stamp: 'KenD 11/22/2016 13:09:26'!
+predicateTester
+
+	| p pred |
+	predicates isEmpty ifTrue: [^nil].
+	p := self optimizeSet: predicates.	"also allows copying closures"
+	^p size = 1
+		ifTrue: 
+			[pred := p first.
+			[:char :matcher | pred value: char]]
+		ifFalse: 
+			[[:char :m | p includes: [:some | some value: char]]]! !
+
+!RxMatchOptimizer methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+prefixTester
+
+	| p prefixChar |
+	prefixes isEmpty ifTrue: [^nil].
+	p := self optimizeSet: prefixes. "also allows copying closures"
+	ignoreCase ifTrue: [p := p collect: [:each | each asUppercase]].
+	^p size = 1 "might be a pretty common case"
+		ifTrue: 
+			[prefixChar := p first.
+			ignoreCase
+				ifTrue: [[:char :matcher | char sameAs: prefixChar]]
+				ifFalse: [[:char :matcher | char = prefixChar]]]
+		ifFalse:
+			[ignoreCase
+				ifTrue: [[:char :matcher | p includes: char asUppercase]]
+				ifFalse: [[:char :matcher | p includes: char]]]! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxAny
+	"Any special char is among the prefixes."
+
+	conditions add: #any! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxBeginningOfLine
+	"Beginning of line is among the prefixes."
+
+	conditions add: #atBeginningOfLine! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxBeginningOfWord
+	"Beginning of line is among the prefixes."
+
+	conditions add: #atBeginningOfWord! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxBranch: branchNode
+	"If the head piece of the branch is transparent (allows 0 matches),
+	we must recurse down the branch. Otherwise, just the head atom
+	is important."
+
+	(branchNode piece isNullable and: [branchNode branch notNil])
+		ifTrue: [branchNode branch dispatchTo: self].
+	branchNode piece dispatchTo: self! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxCharSet: charSetNode 
+	"All these (or none of these) characters is the prefix."
+
+	charSetNode isNegated
+		ifTrue: [nonPrefixes addAll: (charSetNode enumerableSetIgnoringCase: ignoreCase)]
+		ifFalse: [prefixes addAll: (charSetNode enumerableSetIgnoringCase: ignoreCase)].
+	charSetNode hasPredicates ifTrue: 
+			[charSetNode isNegated
+				ifTrue: [nonPredicates addAll: charSetNode predicates]
+				ifFalse: [predicates addAll: charSetNode predicates]]! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxCharacter: charNode
+	"This character is the prefix, of one of them."
+
+	prefixes add: charNode character! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxEndOfLine
+	"Beginning of line is among the prefixes."
+
+	conditions add: #atEndOfLine! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxEndOfWord
+
+	conditions add: #atEndOfWord! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxEpsilon
+	"Empty string, terminate the recursion (do nothing)."! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxMessagePredicate: messagePredicateNode 
+	messagePredicateNode negated
+		ifTrue: [nonMethodPredicates add: messagePredicateNode selector]
+		ifFalse: [methodPredicates add: messagePredicateNode selector]! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxNonWordBoundary
+
+	conditions add: #notAtWordBoundary! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxPiece: pieceNode
+	"Pass on to the atom."
+
+	pieceNode atom dispatchTo: self! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxPredicate: predicateNode 
+
+	predicates add: predicateNode predicate! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxRegex: regexNode
+	"All prefixes of the regex's branches should be combined.
+	Therefore, just recurse."
+
+	regexNode branch dispatchTo: self.
+	regexNode regex notNil
+		ifTrue: [regexNode regex dispatchTo: self]! !
+
+!RxMatchOptimizer methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxWordBoundary
+
+	conditions add: #atWordBoundary! !
+
+!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+allocateMarker
+	"Answer an integer to use as an index of the next marker."
+
+	markerCount := markerCount + 1.
+	^markerCount! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
+atBeginningOfLine
+
+	^self position = 0 or: [self lastChar = Cr]! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
+atBeginningOfWord
+
+	^(self isWordChar: self lastChar) not
+		and: [self isWordChar: stream peek]! !
+
+!RxMatcher methodsFor: 'streaming' stamp: 'vb 4/11/09 21:56'!
+atEnd
+
+	^stream atEnd! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+atEndOfLine
+
+	^self atEnd or: [stream peek = Cr]! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
+atEndOfWord
+
+	^(self isWordChar: self lastChar)
+		and: [(self isWordChar: stream peek) not]! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'lr 1/15/2010 21:12'!
+atWordBoundary
+
+	^(self isWordChar: self lastChar)
+		xor: (self isWordChar: stream peek)! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+buildFrom: aSyntaxTreeRoot
+	"Private - Entry point of matcher build process."
+
+	markerCount := 0.  "must go before #dispatchTo: !!"
+	matcher := aSyntaxTreeRoot dispatchTo: self.
+	matcher terminateWith: RxmTerminator new! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+copy: aString replacingMatchesWith: replacementString
+	"Copy <aString>, except for the matches. Replace each match with <aString>."
+
+	| answer |
+	answer := (String new: 40) writeStream.
+	self
+		copyStream: aString readStream
+		to: answer
+		replacingMatchesWith: replacementString.
+	^answer contents! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+copy: aString translatingMatchesUsing: aBlock
+	"Copy <aString>, except for the matches. For each match, evaluate <aBlock> passing the matched substring as the argument.  Expect the block to answer a String, and replace the match with the answer."
+
+	| answer |
+	answer := (String new: 40) writeStream.
+	self copyStream: aString readStream to: answer translatingMatchesUsing: aBlock.
+	^answer contents! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'lr 1/15/2010 21:45'!
+copyStream: aStream to: writeStream replacingMatchesWith: aString
+	"Copy the contents of <aStream> on the <writeStream>, except for the matches. Replace each match with <aString>."
+
+	| searchStart matchStart matchEnd |
+	stream := aStream.
+	markerPositions := nil.
+	[searchStart := aStream position.
+	self proceedSearchingStream: aStream] whileTrue:
+		[matchStart := (self subBeginning: 1) first.
+		matchEnd := (self subEnd: 1) first.
+		aStream position: searchStart.
+		searchStart to: matchStart - 1 do:
+			[:ignoredPos | writeStream nextPut: aStream next].
+		writeStream nextPutAll: aString.
+		aStream position: matchEnd.
+		"Be extra careful about successful matches which consume no input.
+		After those, make sure to advance or finish if already at end."
+		matchEnd = searchStart ifTrue: 
+			[aStream atEnd
+				ifTrue:	[^self "rest after end of whileTrue: block is a no-op if atEnd"]
+				ifFalse:	[writeStream nextPut: aStream next]]].
+	aStream position: searchStart.
+	[aStream atEnd] whileFalse: [writeStream nextPut: aStream next]! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'lr 1/15/2010 21:45'!
+copyStream: aStream to: writeStream translatingMatchesUsing: aBlock
+	"Copy the contents of <aStream> on the <writeStream>, except for the matches. For each match, evaluate <aBlock> passing the matched substring as the argument.  Expect the block to answer a String, and write the answer to <writeStream> in place of the match."
+
+	| searchStart matchStart matchEnd match |
+	stream := aStream.	
+	markerPositions := nil.
+	[searchStart := aStream position.
+	self proceedSearchingStream: aStream] whileTrue:
+		[matchStart := (self subBeginning: 1) first.
+		matchEnd := (self subEnd: 1) first.
+		aStream position: searchStart.
+		searchStart to: matchStart - 1 do:
+			[:ignoredPos | writeStream nextPut: aStream next].
+		match := (String new: matchEnd - matchStart + 1) writeStream.
+		matchStart to: matchEnd - 1 do:
+			[:ignoredPos | match nextPut: aStream next].
+		writeStream nextPutAll: (aBlock value: match contents).
+		"Be extra careful about successful matches which consume no input.
+		After those, make sure to advance or finish if already at end."
+		matchEnd = searchStart ifTrue: 
+			[aStream atEnd
+				ifTrue:	[^self "rest after end of whileTrue: block is a no-op if atEnd"]
+				ifFalse:	[writeStream nextPut: aStream next]]].
+	aStream position: searchStart.
+	[aStream atEnd] whileFalse: [writeStream nextPut: aStream next]! !
+
+!RxMatcher methodsFor: 'privileged' stamp: 'lr 1/15/2010 21:13'!
+currentState
+	"Answer an opaque object that can later be used to restore the
+	matcher's state (for backtracking)."
+
+	| origPosition origLastChar |
+	origPosition := stream position.
+	^	[stream position: origPosition]! !
+
+!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+hookBranchOf: regexNode onto: endMarker
+	"Private - Recurse down the chain of regexes starting at
+	regexNode, compiling their branches and hooking their tails 
+	to the endMarker node."
+
+	| rest |
+	rest := regexNode regex isNil
+		ifTrue: [nil]
+		ifFalse: [self hookBranchOf: regexNode regex onto: endMarker].
+	^RxmBranch new
+		next: ((regexNode branch dispatchTo: self)
+					pointTailTo: endMarker; 
+					yourself);
+		alternative: rest;
+		yourself! !
+
+!RxMatcher methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initialize: syntaxTreeRoot ignoreCase: aBoolean
+	"Compile thyself for the regex with the specified syntax tree.
+	See comment and `building' protocol in this class and 
+	#dispatchTo: methods in syntax tree components for details 
+	on double-dispatch building. 
+	The argument is supposedly a RxsRegex."
+
+	ignoreCase := aBoolean.
+	self buildFrom: syntaxTreeRoot.
+	startOptimizer := RxMatchOptimizer new initialize: syntaxTreeRoot ignoreCase: aBoolean! !
+
+!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+isWordChar: aCharacterOrNil
+	"Answer whether the argument is a word constituent character:
+	alphanumeric or _."
+
+	^aCharacterOrNil ~~ nil
+		and: [aCharacterOrNil isAlphaNumeric]! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'lr 1/15/2010 21:14'!
+lastChar
+	^ stream position = 0
+		ifFalse: [ stream skip: -1; next ]! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+lastResult
+
+	^lastResult! !
+
+!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+makeOptional: aMatcher
+	"Private - Wrap this matcher so that the result would match 0 or 1
+	occurrences of the matcher."
+
+	| dummy branch |
+	dummy := RxmLink new.
+	branch := (RxmBranch new beLoopback)
+		next: aMatcher;
+		alternative: dummy.
+	aMatcher pointTailTo: dummy.
+	^branch! !
+
+!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+makePlus: aMatcher
+	"Private - Wrap this matcher so that the result would match 1 and more
+	occurrences of the matcher."
+
+	| loopback |
+	loopback := (RxmBranch new beLoopback)
+		next: aMatcher.
+	aMatcher pointTailTo: loopback.
+	^aMatcher! !
+
+!RxMatcher methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+makeStar: aMatcher
+	"Private - Wrap this matcher so that the result would match 0 and more
+	occurrences of the matcher."
+
+	| dummy detour loopback |
+	dummy := RxmLink new.
+	detour := RxmBranch new
+		next: aMatcher;
+		alternative: dummy.
+	loopback := (RxmBranch new beLoopback)
+		next: aMatcher;
+		alternative: dummy.
+	aMatcher pointTailTo: loopback.
+	^detour! !
+
+!RxMatcher methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
+markerPositionAt: anIndex add: position
+	"Remember position of another instance of the given marker."
+
+	(markerPositions at: anIndex) addFirst: position! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+matches: aString
+	"Match against a string."
+
+	^self matchesStream: aString readStream! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesIn: aString
+	"Search aString repeatedly for the matches of the receiver.  Answer an OrderedCollection of all matches (substrings)."
+
+	| result |
+	result := OrderedCollection new.
+	self
+		matchesOnStream: aString readStream
+		do: [:match | result add: match].
+	^result! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesIn: aString collect: aBlock
+	"Search aString repeatedly for the matches of the receiver.  Evaluate aBlock for each match passing the matched substring as the argument, collect evaluation results in an OrderedCollection, and return in. The following example shows how to use this message to split a string into words."
+	"'\w+' asRegex matchesIn: 'Now is the Time' collect: [:each | each asLowercase]"
+
+	| result |
+	result := OrderedCollection new.
+	self
+		matchesOnStream: aString readStream
+		do: [:match | result add: (aBlock value: match)].
+	^result! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesIn: aString do: aBlock
+	"Search aString repeatedly for the matches of the receiver.
+	Evaluate aBlock for each match passing the matched substring
+	as the argument."
+
+	self
+		matchesOnStream: aString readStream
+		do: aBlock! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesOnStream: aStream
+
+	| result |
+	result := OrderedCollection new.
+	self
+		matchesOnStream: aStream
+		do: [:match | result add: match].
+	^result! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesOnStream: aStream collect: aBlock
+
+	| result |
+	result := OrderedCollection new.
+	self
+		matchesOnStream: aStream
+		do: [:match | result add: (aBlock value: match)].
+	^result! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchesOnStream: aStream do: aBlock
+	"Be extra careful about successful matches which consume no input.
+	After those, make sure to advance or finish if already at end."
+
+	| position |
+	[position := aStream position.
+	self searchStream: aStream] whileTrue:
+		[aBlock value: (self subexpression: 1).
+		position = aStream position ifTrue: 
+			[aStream atEnd
+				ifTrue: [^self]
+				ifFalse: [aStream next]]]! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+matchesPrefix: aString
+	"Match against a string."
+
+	^self matchesStreamPrefix: aString readStream! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+matchesStream: theStream
+	"Match thyself against a positionable stream."
+
+	^(self matchesStreamPrefix: theStream)
+		and: [stream atEnd]! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'lr 1/15/2010 21:45'!
+matchesStreamPrefix: theStream
+	"Match thyself against a positionable stream."
+
+	stream := theStream.
+	markerPositions := nil.
+	^self tryMatch! !
+
+!RxMatcher methodsFor: 'match enumeration' stamp: 'vb 4/11/09 21:56'!
+matchingRangesIn: aString
+	"Search aString repeatedly for the matches of the receiver.  Answer an OrderedCollection of ranges of each match (index of first character to: index of last character)."
+
+	| result |
+	result := OrderedCollection new.
+	self
+		matchesIn: aString 
+		do: [:match | result add: (self position - match size + 1 to: self position)].
+	^result! !
+
+!RxMatcher methodsFor: 'streaming' stamp: 'lr 1/15/2010 21:13'!
+next
+	^ stream next! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+notAtWordBoundary
+
+	^self atWordBoundary not! !
+
+!RxMatcher methodsFor: 'streaming' stamp: 'vb 4/11/09 21:56'!
+position
+
+	^stream position! !
+
+!RxMatcher methodsFor: 'private' stamp: 'lr 1/15/2010 21:17'!
+proceedSearchingStream: aStream
+
+	| position |
+	position := aStream position.
+	[aStream atEnd] whileFalse:
+		[self tryMatch ifTrue: [^true].
+		aStream position: position; next.
+		position := aStream position].
+	"Try match at the very stream end too!!"
+	self tryMatch ifTrue: [^true]. 
+	^false! !
+
+!RxMatcher methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
+restoreState: aBlock
+
+	aBlock value! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+search: aString
+	"Search the string for occurrence of something matching myself.
+	Answer a Boolean indicating success."
+
+	^self searchStream: aString readStream! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'lr 1/15/2010 21:45'!
+searchStream: aStream
+	"Search the stream for occurrence of something matching myself.
+	After the search has occurred, stop positioned after the end of the
+	matched substring. Answer a Boolean indicating success."
+
+	| position |
+	stream := aStream.
+	position := aStream position.
+	markerPositions := nil.
+	[aStream atEnd] whileFalse:
+		[self tryMatch ifTrue: [^true].
+		aStream position: position; next.
+		position := aStream position].
+	"Try match at the very stream end too!!"
+	self tryMatch ifTrue: [^true]. 
+	^false! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'jannik.laval 5/2/2010 06:53'!
+split: aString
+	| result lastPosition |
+
+	result := OrderedCollection new.
+	stream := aString readStream.
+	lastPosition := stream position.
+	[ self searchStream: stream ] whileTrue:
+		[ result add: (aString copyFrom: lastPosition+1 to: (self subBeginning: 1) first).
+		[lastPosition < stream position] assertWithDescription: 'Regex cannot match null string'.
+		lastPosition := stream position ].
+	result add: (aString copyFrom: lastPosition+1 to: aString size).
+	^ result! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+subBeginning: subIndex
+
+	^markerPositions at: subIndex * 2 - 1! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+subEnd: subIndex
+
+	^markerPositions at: subIndex * 2! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+subexpression: subIndex
+	"Answer a string that matched the subexpression at the given index.
+	If there are multiple matches, answer the last one.
+	If there are no matches, answer nil. 
+	(NB: it used to answer an empty string but I think nil makes more sense)."
+
+	| matches |
+	matches := self subexpressions: subIndex.
+	^matches isEmpty ifTrue: [nil] ifFalse: [matches last]! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+subexpressionCount
+
+	^markerCount // 2! !
+
+!RxMatcher methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+subexpressions: subIndex
+	"Answer an array of all matches of the subexpression at the given index.
+	The answer is always an array; it is empty if there are no matches."
+
+	| originalPosition startPositions stopPositions reply |
+	originalPosition := stream position.
+	startPositions := self subBeginning: subIndex.
+	stopPositions := self subEnd: subIndex.
+	(startPositions isEmpty or: [stopPositions isEmpty]) ifTrue: [^Array new].
+	reply := OrderedCollection new.
+	startPositions with: stopPositions do:
+		[:start :stop |
+		stream position: start.
+		reply add: (stream next: stop - start)].
+	stream position: originalPosition.
+	^reply asArray! !
+
+!RxMatcher methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+supportsSubexpressions
+
+	^true! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxAny
+	"Double dispatch from the syntax tree. 
+	Create a matcher for any non-null character."
+
+	^RxmPredicate new
+		predicate: [:char | char asInteger ~= 0]! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxBeginningOfLine
+	"Double dispatch from the syntax tree. 
+	Create a matcher for beginning-of-line condition."
+
+	^RxmSpecial new beBeginningOfLine! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxBeginningOfWord
+	"Double dispatch from the syntax tree. 
+	Create a matcher for beginning-of-word condition."
+
+	^RxmSpecial new beBeginningOfWord! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'PeterHugossonMiller 9/3/2009 11:08'!
+syntaxBranch: branchNode
+	"Double dispatch from the syntax tree. 
+	Branch node is a link in a chain of concatenated pieces.
+	First build the matcher for the rest of the chain, then make 
+	it for the current piece and hook the rest to it."
+	| result next rest |
+	branchNode branch isNil
+		ifTrue: [^branchNode piece dispatchTo: self].
+	"Optimization: glue a sequence of individual characters into a single string to match."
+	branchNode piece isAtomic ifTrue:
+		[result := (String new: 40) writeStream.
+		next := branchNode tryMergingInto: result.
+		result := result contents.
+		result size > 1 ifTrue: "worth merging"
+			[rest := next notNil 
+				ifTrue: [next dispatchTo: self]
+				ifFalse: [nil].
+			^(RxmSubstring new substring: result ignoreCase: ignoreCase)
+				pointTailTo: rest;
+				yourself]].
+	"No optimization possible or worth it, just concatenate all. "
+	^(branchNode piece dispatchTo: self)
+		pointTailTo: (branchNode branch dispatchTo: self);
+		yourself! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxCharSet: charSetNode
+	"Double dispatch from the syntax tree. 
+	A character set is a few characters, and we either match any of them,
+	or match any that is not one of them."
+
+	^RxmPredicate with: (charSetNode predicateIgnoringCase: ignoreCase)! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxCharacter: charNode
+	"Double dispatch from the syntax tree. 
+	We get here when no merging characters into strings was possible."
+
+	| wanted |
+	wanted := charNode character.
+	^RxmPredicate new predicate: 
+		(ignoreCase
+			ifTrue: [[:char | char sameAs: wanted]]
+			ifFalse: [[:char | char = wanted]])! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxEndOfLine
+	"Double dispatch from the syntax tree. 
+	Create a matcher for end-of-line condition."
+
+	^RxmSpecial new beEndOfLine! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxEndOfWord
+	"Double dispatch from the syntax tree. 
+	Create a matcher for end-of-word condition."
+
+	^RxmSpecial new beEndOfWord! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxEpsilon
+	"Double dispatch from the syntax tree. Match empty string. This is unlikely
+	to happen in sane expressions, so we'll live without special epsilon-nodes."
+
+	^RxmSubstring new
+		substring: String new
+		ignoreCase: ignoreCase! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxMessagePredicate: messagePredicateNode
+	"Double dispatch from the syntax tree. 
+	Special link can handle predicates."
+
+	^messagePredicateNode negated
+		ifTrue: [RxmPredicate new bePerformNot: messagePredicateNode selector]
+		ifFalse: [RxmPredicate new bePerform: messagePredicateNode selector]! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxNonWordBoundary
+	"Double dispatch from the syntax tree. 
+	Create a matcher for the word boundary condition."
+
+	^RxmSpecial new beNotWordBoundary! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxPiece: pieceNode
+	"Double dispatch from the syntax tree. 
+	Piece is an atom repeated a few times. Take care of a special
+	case when the atom is repeated just once."
+
+	| atom |
+	atom := pieceNode atom dispatchTo: self.
+	^pieceNode isSingular
+		ifTrue: [atom]
+		ifFalse: [pieceNode isStar
+			ifTrue: [self makeStar: atom]
+			ifFalse: [pieceNode isPlus
+				ifTrue: [self makePlus: atom]
+				ifFalse: [pieceNode isOptional
+					ifTrue: [self makeOptional: atom]
+					ifFalse: [RxParser signalCompilationException: 
+						'repetitions are not supported by RxMatcher']]]]! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxPredicate: predicateNode
+	"Double dispatch from the syntax tree. 
+	A character set is a few characters, and we either match any of them,
+	or match any that is not one of them."
+
+	^RxmPredicate with: predicateNode predicate! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxRegex: regexNode
+	"Double dispatch from the syntax tree. 
+	Regex node is a chain of branches to be tried. Should compile this 
+	into a bundle of parallel branches, between two marker nodes." 
+	
+	| startIndex endIndex endNode alternatives |
+	startIndex := self allocateMarker.
+	endIndex := self allocateMarker.
+	endNode := RxmMarker new index: endIndex.
+	alternatives := self hookBranchOf: regexNode onto: endNode.
+	^(RxmMarker new index: startIndex)
+		pointTailTo: alternatives;
+		yourself! !
+
+!RxMatcher methodsFor: 'double dispatch' stamp: 'vb 4/11/09 21:56'!
+syntaxWordBoundary
+	"Double dispatch from the syntax tree. 
+	Create a matcher for the word boundary condition."
+
+	^RxmSpecial new beWordBoundary! !
+
+!RxMatcher methodsFor: 'private' stamp: 'lr 1/15/2010 21:51'!
+tryMatch
+	"Match thyself against the current stream."
+
+	| oldMarkerPositions |
+	oldMarkerPositions := markerPositions.
+	markerPositions := Array new: markerCount.
+	1 to: markerCount do: [ :i | markerPositions at: i put: OrderedCollection new ].
+	lastResult := startOptimizer isNil
+		ifTrue: [ matcher matchAgainst: self]
+		ifFalse: [ (startOptimizer canStartMatch: stream peek in: self) and: [ matcher matchAgainst: self ] ].
+	"check for duplicates"
+	(lastResult not or: [ oldMarkerPositions isNil or: [ oldMarkerPositions size ~= markerPositions size ] ])
+		ifTrue: [ ^ lastResult ].
+	oldMarkerPositions with: markerPositions do: [ :oldPos :newPos |
+		oldPos size = newPos size 
+			ifFalse: [ ^ lastResult ].
+		oldPos with: newPos do: [ :old :new |
+			old = new
+				ifFalse: [ ^ lastResult ] ] ].
+	"this is a duplicate"
+	^ lastResult := false! !
+
+!RxMatcher class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
+for: aRegex
+	"Create and answer a matcher that will match a regular expression
+	specified by the syntax tree of which `aRegex' is a root."
+
+	^self for: aRegex ignoreCase: false! !
+
+!RxMatcher class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
+for: aRegex ignoreCase: aBoolean
+	"Create and answer a matcher that will match a regular expression
+	specified by the syntax tree of which `aRegex' is a root."
+
+	^self new
+		initialize: aRegex
+		ignoreCase: aBoolean! !
+
+!RxMatcher class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
+forString: aString
+	"Create and answer a matcher that will match the regular expression
+	`aString'."
+
+	^self for: (RxParser new parse: aString)! !
+
+!RxMatcher class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
+forString: aString ignoreCase: aBoolean
+	"Create and answer a matcher that will match the regular expression
+	`aString'."
+
+	^self for: (RxParser new parse: aString) ignoreCase: aBoolean! !
+
+!RxMatcher class methodsFor: 'class initialization' stamp: 'avi 11/30/2003 13:30'!
+initialize
+	"RxMatcher initialize"
+	Cr := Character cr.
+	Lf := Character lf.! !
+
+!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
+atom
+	"An atom is one of a lot of possibilities, see below."
+
+	| atom |
+	(lookahead = #epsilon or: 
+			[lookahead = $| or: 
+					[lookahead = $)
+						or: [lookahead = $* or: [lookahead = $+ or: [lookahead = $?]]]]])
+		ifTrue: [^RxsEpsilon new].
+	lookahead = $( ifTrue: 
+			["<atom> ::= '(' <regex> ')' "
+
+			self match: $(.
+			atom := self regex.
+			self match: $).
+			^atom].
+	lookahead = $[ ifTrue: 
+			["<atom> ::= '[' <characterSet> ']' "
+
+			self match: $[.
+			atom := self characterSet.
+			self match: $].
+			^atom].
+	lookahead = $: ifTrue: 
+			["<atom> ::= ':' <messagePredicate> ':' "
+
+			self match: $:.
+			atom := self messagePredicate.
+			self match: $:.
+			^atom].
+	lookahead = $. ifTrue: 
+			["any non-whitespace character"
+
+			self next.
+			^RxsContextCondition new beAny].
+	lookahead = $^ ifTrue: 
+			["beginning of line condition"
+
+			self next.
+			^RxsContextCondition new beBeginningOfLine].
+	lookahead = $$ ifTrue: 
+			["end of line condition"
+
+			self next.
+			^RxsContextCondition new beEndOfLine].
+	lookahead = $\ ifTrue: 
+			["<atom> ::= '\' <character>"
+			self next.
+			lookahead = #epsilon ifTrue: 
+				[self signalParseError: 'bad quotation'].
+			(BackslashConstants includesKey: lookahead) ifTrue:
+				[atom := RxsCharacter with: (BackslashConstants at: lookahead).
+				self next.
+				^atom].
+			self ifSpecial: lookahead
+				then: [:node | self next. ^node]].
+	"If passed through the above, the following is a regular character."
+	atom := RxsCharacter with: lookahead.
+	self next.
+	^atom! !
+
+!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
+branch
+	"<branch> ::= e | <piece> <branch>"
+
+	| piece branch |
+	piece := self piece.
+	(lookahead = #epsilon or: [lookahead = $| or: [lookahead = $) ]])
+		ifTrue: [branch := nil]
+		ifFalse: [branch := self branch].
+	^RxsBranch new 
+		initializePiece: piece 
+		branch: branch! !
+
+!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
+characterSet
+	"Match a range of characters: something between `[' and `]'.
+	Opening bracked has already been seen, and closing should
+	not be consumed as well. Set spec is as usual for
+	sets in regexes."
+
+	| spec errorMessage |
+	errorMessage := ' no terminating "]"'.
+	spec := self inputUpTo: $] nestedOn: $[ errorMessage: errorMessage.
+	(spec isEmpty or: [spec = '^']) ifTrue: "This ']' was literal."
+		[self next.
+		spec := spec, ']', (self inputUpTo: $] nestedOn: $[ errorMessage: errorMessage)].
+	^self characterSetFrom: spec! !
+
+!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+characterSetFrom: setSpec
+	"<setSpec> is what goes between the brackets in a charset regex
+	(a String). Make a string containing all characters the spec specifies.
+	Spec is never empty."
+
+	| negated spec |
+	spec := ReadStream on: setSpec.
+	spec peek = $^
+		ifTrue: 	[negated := true.
+				spec next]
+		ifFalse:	[negated := false].
+	^RxsCharSet new
+		initializeElements: (RxCharSetParser on: spec) parse
+		negated: negated! !
+
+!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+ifSpecial: aCharacter then: aBlock
+	"If the character is such that it defines a special node when follows a $\,
+	then create that node and evaluate aBlock with the node as the parameter.
+	Otherwise just return."
+
+	| classAndSelector |
+	classAndSelector := BackslashSpecials at: aCharacter ifAbsent: [^self].
+	^aBlock value: (classAndSelector key new perform: classAndSelector value)! !
+
+!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+inputUpTo: aCharacter errorMessage: aString
+	"Accumulate input stream until <aCharacter> is encountered
+	and answer the accumulated chars as String, not including
+	<aCharacter>. Signal error if end of stream is encountered,
+	passing <aString> as the error description."
+
+	| accumulator |
+	accumulator := WriteStream on: (String new: 20).
+	[lookahead ~= aCharacter and: [lookahead ~= #epsilon]]
+		whileTrue:
+			[accumulator nextPut: lookahead.
+			self next].
+	lookahead = #epsilon ifTrue: [self signalParseError: aString].
+	^accumulator contents! !
+
+!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+inputUpTo: aCharacter nestedOn: anotherCharacter errorMessage: aString 
+	"Accumulate input stream until <aCharacter> is encountered
+	and answer the accumulated chars as String, not including
+	<aCharacter>. Signal error if end of stream is encountered,
+	passing <aString> as the error description."
+
+	| accumulator nestLevel |
+	accumulator := WriteStream on: (String new: 20).
+	nestLevel := 0.
+	[lookahead ~= aCharacter or: [nestLevel > 0]] whileTrue: 
+			[#epsilon = lookahead ifTrue: [self signalParseError: aString].
+			accumulator nextPut: lookahead.
+			lookahead = anotherCharacter ifTrue: [nestLevel := nestLevel + 1].
+			lookahead = aCharacter ifTrue: [nestLevel := nestLevel - 1].
+			self next].
+	^accumulator contents! !
+
+!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+match: aCharacter
+	"<aCharacter> MUST match the current lookeahead.
+	If this is the case, advance the input. Otherwise, blow up."
+
+	aCharacter ~= lookahead 
+		ifTrue: [^self signalParseError].	"does not return"
+	self next! !
+
+!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
+messagePredicate
+	"Match a message predicate specification: a selector (presumably
+	understood by a Character) enclosed in :'s ."
+
+	| spec negated |
+	spec := (self inputUpTo: $: errorMessage: ' no terminating ":"').
+	negated := false.
+	spec first = $^ ifTrue:
+		[negated := true.
+		spec := spec copyFrom: 2 to: spec size].
+	^RxsMessagePredicate new 
+		initializeSelector: spec asSymbol
+		negated: negated! !
+
+!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+next
+	"Advance the input storing the just read character
+	as the lookahead."
+
+	input atEnd
+		ifTrue: [lookahead := #epsilon]
+		ifFalse: [lookahead := input next]! !
+
+!RxParser methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+parse: aString
+	"Parse input from a string <aString>.
+	On success, answers an RxsRegex -- parse tree root.
+	On error, raises `RxParser syntaxErrorSignal' with the current
+	input stream position as the parameter."
+
+	^self parseStream: (ReadStream on: aString)! !
+
+!RxParser methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+parseStream: aStream
+	"Parse an input from a character stream <aStream>.
+	On success, answers an RxsRegex -- parse tree root.
+	On error, raises `RxParser syntaxErrorSignal' with the current
+	input stream position as the parameter."
+
+	| tree |
+	input := aStream.
+	lookahead := nil.
+	self match: nil.
+	tree := self regex.
+	self match: #epsilon.
+	^tree! !
+
+!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
+piece
+	"<piece> ::= <atom> | <atom>* | <atom>+ | <atom>?"
+
+	| atom errorMessage |
+	errorMessage := ' nullable closure'.
+	atom := self atom.
+	lookahead = $* ifTrue: 
+		[self next.
+		atom isNullable ifTrue: [self signalParseError: errorMessage].
+		^RxsPiece new initializeStarAtom: atom].
+	lookahead = $+ ifTrue: 
+		[self next.
+		atom isNullable ifTrue: [self signalParseError: errorMessage].
+		^RxsPiece new initializePlusAtom: atom].
+	lookahead = $? ifTrue: 
+		[self next.
+		atom isNullable ifTrue: [self signalParseError: errorMessage].
+		^RxsPiece new initializeOptionalAtom: atom].
+	^RxsPiece new initializeAtom: atom! !
+
+!RxParser methodsFor: 'recursive descent' stamp: 'vb 4/11/09 21:56'!
+regex
+	"<regex> ::= e | <branch> `|' <regex>"
+
+	| branch regex |
+	branch := self branch.
+	(lookahead = #epsilon or: [lookahead = $)])
+		ifTrue: [regex := nil]
+		ifFalse: 
+			[self match: $|.
+			regex := self regex].
+	^RxsRegex new initializeBranch: branch regex: regex! !
+
+!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+signalParseError
+
+	self class signalSyntaxException: 'Regex syntax error'! !
+
+!RxParser methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+signalParseError: aString
+
+	self class signalSyntaxException: aString! !
+
+!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'vb 4/11/09 21:56'!
+a: x introduction: xx 
+" 
+A regular expression is a template specifying a class of strings. A
+regular expression matcher is an tool that determines whether a string
+belongs to a class specified by a regular expression.  This is a
+common task of a user input validation code, and the use of regular
+expressions can GREATLY simplify and speed up development of such
+code.  As an example, here is how to verify that a string is a valid
+hexadecimal number in Smalltalk notation, using this matcher package:
+
+	aString matchesRegex: '16r[[:xdigit:]]+'
+
+(Coding the same ``the hard way'' is an exercise to a curious reader).
+
+This matcher is offered to the Smalltalk community in hope it will be
+useful. It is free in terms of money, and to a large extent--in terms
+of rights of use. Refer to `Boring Stuff' section for legalese.
+
+The 'What's new in this release' section describes the functionality
+introduced in 1.1 release.
+
+The `Syntax' section explains the recognized syntax of regular
+expressions.
+
+The `Usage' section explains matcher capabilities that go beyond what
+String>>matchesRegex: method offers.
+
+The `Implementation notes' sections says a few words about what is
+under the hood.
+
+Happy hacking,
+
+--Vassili Bykov 
+<vassili@objectpeople.com> <vassili@magma.ca>
+
+August 6, 1996
+April 4, 1999
+"
+
+	self error: 'comment only'! !
+
+!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'lr 1/7/2010 20:10'!
+b: x whatsNewInThisRelease: xx
+"
+VERSION 1.3.1 (September 2008)
+1. Updated documentation of character classes, making clear the problems of locale - an area for future improvement
+
+VERSION 1.3 (September 2008)
+1. \w now matches underscore as well as alphanumerics, in line with most other regex libraries (and our documentation!!).  
+2. \W rejects underscore as well as alphanumerics
+3. added tests for this at end of testSuite
+4. updated documentation and added note to old incorrect comments in version 1.1 below
+
+VERSION 1.2.3 (November 2007)
+
+1. Regexs with ^ or $ applied to copy empty strings caused infinite loops, e.g. ('' copyWithRegex: '^.*$' matchesReplacedWith: 'foo'). Applied a similar correction to that from version 1.1c, to #copyStream:to:(replacingMatchesWith:|translatingMatchesUsing:).
+2. Extended RxParser testing to run each test for #copy:translatingMatchesUsing: as well as #search:.
+3. Corrected #testSuite test that a dot does not match a null, which was passing by luck with Smalltalk code in a literal array.
+4. Added test to end of test suite for fix 1 above.
+
+VERSION 1.2.2 (November 2006)
+
+There was no way to specify a backslash in a character set. Now [\\] is accepted.
+
+VERSION 1.2.1	(August 2006)
+
+1. Support for returning all ranges (startIndex to: stopIndex) matching a regex - #allRangesOfRegexMatches:, #matchingRangesIn:
+2. Added hint to usage documentation on how to get more information about matches when enumerating
+3. Syntax description of dot corrected: matches anything but NUL since 1.1a
+
+VERSION 1.2	(May 2006)
+
+Fixed case-insensitive search for character sets.
+
+VERSION 1.1c	(December 2004)
+
+Fixed the issue with #matchesOnStream:do: which caused infinite loops for matches 
+that matched empty strings.
+
+VERSION 1.1b	(November 2001)
+
+Changes valueNowOrOnUnwindDo: to ensure:, plus incorporates some earlier fixes.
+
+VERSION 1.1a	(May 2001)
+
+1. Support for keeping track of multiple subexpressions.
+2. Dot (.) matches anything but NUL character, as it should per POSIX spec.
+3. Some bug fixes.
+
+VERSION 1.1	(October 1999)
+
+Regular expression syntax corrections and enhancements:
+
+1. Backslash escapes similar to those in Perl are allowed in patterns:
+
+	\w	any word constituent character (equivalent to [a-zA-Z0-9_]) *** underscore only since 1.3 ***
+	\W	any character but a word constituent (equivalent to [^a-xA-Z0-9_] *** underscore only since 1.3 ***
+	\d	a digit (same as [0-9])
+	\D	anything but a digit
+	\s 	a whitespace character
+	\S	anything but a whitespace character
+	\b	an empty string at a word boundary
+	\B	an empty string not at a word boundary
+	\<	an empty string at the beginning of a word
+	\>	an empty string at the end of a word
+
+For example, '\w+' is now a valid expression matching any word.
+
+2. The following backslash escapes are also allowed in character sets
+(between square brackets):
+
+	\w, \W, \d, \D, \s, and \S.
+
+3. The following grep(1)-compatible named character classes are
+recognized in character sets as well:
+
+	[:alnum:]
+	[:alpha:]
+	[:cntrl:]
+	[:digit:]
+	[:graph:]
+	[:lower:]
+	[:print:]
+	[:punct:]
+	[:space:]
+	[:upper:]
+	[:xdigit:]
+
+For example, the following patterns are equivalent:
+
+	'[[:alnum:]_]+' '\w+'  '[\w]+' '[a-zA-Z0-9_]+' *** underscore only since 1.3 ***
+
+4. Some non-printable characters can be represented in regular
+expressions using a common backslash notation:
+
+	\t	tab (Character tab)
+	\n	newline (Character lf)
+	\r	carriage return (Character cr)
+	\f	form feed (Character newPage)
+	\e	escape (Character esc)
+
+5. A dot is corectly interpreted as 'any character but a newline'
+instead of 'anything but whitespace'.
+
+6. Case-insensitive matching.  The easiest access to it are new
+messages CharacterArray understands: #asRegexIgnoringCase,
+#matchesRegexIgnoringCase:, #prefixMatchesRegexIgnoringCase:.
+
+7. The matcher (an instance of RxMatcher, the result of
+String>>asRegex) now provides a collection-like interface to matches
+in a particular string or on a particular stream, as well as
+substitution protocol. The interface includes the following messages:
+
+	matchesIn: aString
+	matchesIn: aString collect: aBlock
+	matchesIn: aString do: aBlock
+
+	matchesOnStream: aStream
+	matchesOnStream: aStream collect: aBlock
+	matchesOnStream: aStream do: aBlock
+
+	copy: aString translatingMatchesUsing: aBlock
+	copy: aString replacingMatchesWith: replacementString
+
+	copyStream: aStream to: writeStream translatingMatchesUsing: aBlock
+	copyStream: aStream to: writeStream replacingMatchesWith: aString
+
+Examples:
+
+	'\w+' asRegex matchesIn: 'now is the time'
+
+returns an OrderedCollection containing four strings: 'now', 'is',
+'the', and 'time'.
+
+	'\<t\w+' asRegexIgnoringCase
+		copy: 'now is the Time'
+		translatingMatchesUsing: [:match | match asUppercase]
+
+returns 'now is THE TIME' (the regular expression matches words
+beginning with either an uppercase or a lowercase T).
+
+ACKNOWLEDGEMENTS
+
+Since the first release of the matcher, thanks to the input from
+several fellow Smalltalkers, I became convinced a native Smalltalk
+regular expression matcher was worth the effort to keep it alive. For
+the contributions, suggestions, and bug reports that made this release 
+possible, I want to thank:
+
+	Felix Hack
+	Peter Hatch
+	Alan Knight
+	Eliot Miranda
+	Thomas Muhr
+	Robb Shecter
+	David N. Smith
+	Francis Wolinski
+
+and anyone whom I haven't yet met or heard from, but who agrees this
+has not been a complete waste of time.
+
+--Vassili Bykov
+October 3, 1999
+"
+
+	self error: 'comment only'! !
+
+!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'lr 1/7/2010 20:10'!
+c: x syntax: xx
+" 
+
+[You can select and `print it' examples in this method. Just don't
+forget to cancel the changes.]
+
+The simplest regular expression is a single character.  It matches
+exactly that character. A sequence of characters matches a string with
+exactly the same sequence of characters:
+
+	'a' matchesRegex: 'a'				-- true
+	'foobar' matchesRegex: 'foobar'		-- true
+	'blorple' matchesRegex: 'foobar'		-- false
+
+The above paragraph introduced a primitive regular expression (a
+character), and an operator (sequencing). Operators are applied to
+regular expressions to produce more complex regular expressions.
+Sequencing (placing expressions one after another) as an operator is,
+in a certain sense, `invisible'--yet it is arguably the most common.
+
+A more `visible' operator is Kleene closure, more often simply
+referred to as `a star'.  A regular expression followed by an asterisk
+matches any number (including 0) of matches of the original
+expression. For example:
+
+	'ab' matchesRegex: 'a*b'		 		-- true
+	'aaaaab' matchesRegex: 'a*b'	 	-- true
+	'b' matchesRegex: 'a*b'		 		-- true
+	'aac' matchesRegex: 'a*b'	 		-- false: b does not match
+
+A star's precedence is higher than that of sequencing. A star applies
+to the shortest possible subexpression that precedes it. For example,
+'ab*' means `a followed by zero or more occurrences of b', not `zero
+or more occurrences of ab':
+
+	'abbb' matchesRegex: 'ab*'	 		-- true
+	'abab' matchesRegex: 'ab*'		 	-- false
+
+To actually make a regex matching `zero or more occurrences of ab',
+`ab' is enclosed in parentheses:
+
+	'abab' matchesRegex: '(ab)*'		 	-- true
+	'abcab' matchesRegex: '(ab)*'	 	-- false: c spoils the fun
+
+Two other operators similar to `*' are `+' and `?'. `+' (positive
+closure, or simply `plus') matches one or more occurrences of the
+original expression. `?' (`optional') matches zero or one, but never
+more, occurrences.
+
+	'ac' matchesRegex: 'ab*c'	 		-- true
+	'ac' matchesRegex: 'ab+c'	 		-- false: need at least one b
+	'abbc' matchesRegex: 'ab+c'		 	-- true
+	'abbc' matchesRegex: 'ab?c'		 	-- false: too many b's
+
+As we have seen, characters `*', `+', `?', `(', and `)' have special
+meaning in regular expressions. If one of them is to be used
+literally, it should be quoted: preceded with a backslash. (Thus,
+backslash is also special character, and needs to be quoted for a
+literal match--as well as any other special character described
+further).
+
+	'ab*' matchesRegex: 'ab*'		 	-- false: star in the right string is special
+	'ab*' matchesRegex: 'ab\*'	 		-- true
+	'a\c' matchesRegex: 'a\\c'		 	-- true
+
+The last operator is `|' meaning `or'. It is placed between two
+regular expressions, and the resulting expression matches if one of
+the expressions matches. It has the lowest possible precedence (lower
+than sequencing). For example, `ab*|ba*' means `a followed by any
+number of b's, or b followed by any number of a's':
+
+	'abb' matchesRegex: 'ab*|ba*'	 	-- true
+	'baa' matchesRegex: 'ab*|ba*'	 	-- true
+	'baab' matchesRegex: 'ab*|ba*'	 	-- false
+
+A bit more complex example is the following expression, matching the
+name of any of the Lisp-style `car', `cdr', `caar', `cadr',
+... functions:
+
+	c(a|d)+r
+
+It is possible to write an expression matching an empty string, for
+example: `a|'.  However, it is an error to apply `*', `+', or `?' to
+such expression: `(a|)*' is an invalid expression.
+
+So far, we have used only characters as the 'smallest' components of
+regular expressions. There are other, more `interesting', components.
+
+A character set is a string of characters enclosed in square
+brackets. It matches any single character if it appears between the
+brackets. For example, `[01]' matches either `0' or `1':
+
+	'0' matchesRegex: '[01]'		 		-- true
+	'3' matchesRegex: '[01]'		 		-- false
+	'11' matchesRegex: '[01]'		 		-- false: a set matches only one character
+
+Using plus operator, we can build the following binary number
+recognizer:
+
+	'10010100' matchesRegex: '[01]+'	 	-- true
+	'10001210' matchesRegex: '[01]+'	 	-- false
+
+If the first character after the opening bracket is `^', the set is
+inverted: it matches any single character *not* appearing between the
+brackets:
+
+	'0' matchesRegex: '[^01]'		  		-- false
+	'3' matchesRegex: '[^01]'		 		-- true
+
+For convenience, a set may include ranges: pairs of characters
+separated with `-'. This is equivalent to listing all characters
+between them: `[0-9]' is the same as `[0123456789]'.
+
+Special characters within a set are `^', `-', and `]' that closes the
+set. Below are the examples of how to literally use them in a set:
+
+	[01^]		-- put the caret anywhere except the beginning
+	[01-]		-- put the dash as the last character
+	[]01]		-- put the closing bracket as the first character 
+	[^]01]			(thus, empty and universal sets cannot be specified)
+
+Regular expressions can also include the following backquote escapes
+to refer to popular classes of characters:
+
+	\w	any word constituent character (same as [a-zA-Z0-9_])
+	\W	any character but a word constituent
+	\d	a digit (same as [0-9])
+	\D	anything but a digit
+	\s 	a whitespace character (same as [:space:] below)
+	\S	anything but a whitespace character
+
+These escapes are also allowed in character classes: '[\w+-]' means
+'any character that is either a word constituent, or a plus, or a
+minus'.
+
+Character classes can also include the following grep(1)-compatible
+elements to refer to:
+
+	[:alnum:]		any alphanumeric character (same as [a-zA-Z0-9])
+	[:alpha:]		any alphabetic character (same as [a-zA-Z])
+	[:cntrl:]		any control character. (any character with code < 32)
+	[:digit:]		any decimal digit (same as [0-9])
+	[:graph:]		any graphical character. (any character with code >= 32).
+	[:lower:]		any lowercase character (including non-ASCII lowercase characters)
+	[:print:]		any printable character. In this version, this is the same as [:graph:]
+	[:punct:]		any punctuation character:  . , !! ? ; : ' - ( ) ` and double quotes
+	[:space:]		any whitespace character (space, tab, CR, LF, null, form feed, Ctrl-Z, 16r2000-16r200B, 16r3000)
+	[:upper:]		any uppercase character (including non-ASCII uppercase characters)
+	[:xdigit:]		any hexadecimal character (same as [a-fA-F0-9]).
+
+Note that many of these are only as consistent or inconsistent on issues
+of locale as the underlying Smalltalk implementation. Values shown here
+are for VisualWorks 7.6.
+
+Note that these elements are components of the character classes,
+i.e. they have to be enclosed in an extra set of square brackets to
+form a valid regular expression.  For example, a non-empty string of
+digits would be represented as '[[:digit:]]+'.
+
+The above primitive expressions and operators are common to many
+implementations of regular expressions. The next primitive expression
+is unique to this Smalltalk implementation.
+
+A sequence of characters between colons is treated as a unary selector
+which is supposed to be understood by Characters. A character matches
+such an expression if it answers true to a message with that
+selector. This allows a more readable and efficient way of specifying
+character classes. For example, `[0-9]' is equivalent to `:isDigit:',
+but the latter is more efficient. Analogously to character sets,
+character classes can be negated: `:^isDigit:' matches a Character
+that answers false to #isDigit, and is therefore equivalent to
+`[^0-9]'.
+
+As an example, so far we have seen the following equivalent ways to
+write a regular expression that matches a non-empty string of digits:
+
+	'[0-9]+'
+	'\d+'
+	'[\d]+'
+	'[[:digit:]]+'
+	:isDigit:+'
+
+The last group of special primitive expressions includes: 
+
+	.	matching any character except a NULL; 
+	^	matching an empty string at the beginning of a line; 
+	$	matching an empty string at the end of a line.
+	\b	an empty string at a word boundary
+	\B	an empty string not at a word boundary
+	\<	an empty string at the beginning of a word
+	\>	an empty string at the end of a word
+
+	'axyzb' matchesRegex: 'a.+b'		-- true
+	'ax zb' matchesRegex: 'a.+b'			-- true (space is matched by `.')
+	'ax
+zb' matchesRegex: 'a.+b'				-- true (carriage return is matched by `.')
+
+Again, the dot ., caret ^ and dollar $ characters are special and should be quoted
+to be matched literally.
+
+	EXAMPLES
+
+As the introductions said, a great use for regular expressions is user
+input validation. Following are a few examples of regular expressions
+that might be handy in checking input entered by the user in an input
+field. Try them out by entering something between the quotes and
+print-iting. (Also, try to imagine Smalltalk code that each validation
+would require if coded by hand).  Most example expressions could have
+been written in alternative ways.
+
+Checking if aString may represent a nonnegative integer number:
+
+	'' matchesRegex: ':isDigit:+'
+or
+	'' matchesRegex: '[0-9]+'
+or
+	'' matchesRegex: '\d+'
+
+Checking if aString may represent an integer number with an optional
+sign in front:
+
+	'' matchesRegex: '(\+|-)?\d+'
+
+Checking if aString is a fixed-point number, with at least one digit
+is required after a dot:
+
+	'' matchesRegex: '(\+|-)?\d+(\.\d+)?'
+
+The same, but allow notation like `123.':
+
+	'' matchesRegex: '(\+|-)?\d+(\.\d*)?'
+
+Recognizer for a string that might be a name: one word with first
+capital letter, no blanks, no digits.  More traditional:
+
+	'' matchesRegex: '[A-Z][A-Za-z]*'
+
+more Smalltalkish:
+
+	'' matchesRegex: ':isUppercase::isAlphabetic:*'
+
+A date in format MMM DD, YYYY with any number of spaces in between, in
+XX century:
+
+	'' matchesRegex: '(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[ ]+(\d\d?)[ ]*,[ ]*19(\d\d)'
+
+Note parentheses around some components of the expression above. As
+`Usage' section shows, they will allow us to obtain the actual strings
+that have matched them (i.e. month name, day number, and year number).
+
+For dessert, coming back to numbers: here is a recognizer for a
+general number format: anything like 999, or 999.999, or -999.999e+21.
+
+	'' matchesRegex: '(\+|-)?\d+(\.\d*)?((e|E)(\+|-)?\d+)?'
+
+"
+
+	self error: 'comment only'! !
+
+!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'vb 4/11/09 21:56'!
+d: x usage: xx
+" 
+The preceding section covered the syntax of regular expressions. It
+used the simplest possible interface to the matcher: sending
+#matchesRegex: message to the sample string, with regular expression
+string as the argument.  This section explains hairier ways of using
+the matcher.
+
+	PREFIX MATCHING AND CASE-INSENSITIVE MATCHING
+
+A CharacterArray (an EsString in VA) also understands these messages:
+
+	#prefixMatchesRegex: regexString
+	#matchesRegexIgnoringCase: regexString
+	#prefixMatchesRegexIgnoringCase: regexString
+
+#prefixMatchesRegex: is just like #matchesRegex, except that the whole
+receiver is not expected to match the regular expression passed as the
+argument; matching just a prefix of it is enough.  For example:
+
+	'abcde' matchesRegex: '(a|b)+'		-- false
+	'abcde' prefixMatchesRegex: '(a|b)+'	-- true
+
+The last two messages are case-insensitive versions of matching.
+
+	ENUMERATION INTERFACE
+
+An application can be interested in all matches of a certain regular
+expression within a String.  The matches are accessible using a
+protocol modelled after the familiar Collection-like enumeration
+protocol:
+
+	#regex: regexString matchesDo: aBlock
+
+Evaluates a one-argument <aBlock> for every match of the regular
+expression within the receiver string.
+
+	#regex: regexString matchesCollect: aBlock
+
+Evaluates a one-argument <aBlock> for every match of the regular
+expression within the receiver string. Collects results of evaluations
+and anwers them as a SequenceableCollection.
+
+	#allRegexMatches: regexString
+
+Returns a collection of all matches (substrings of the receiver
+string) of the regular expression.  It is an equivalent of <aString
+regex: regexString matchesCollect: [:each | each]>.
+
+	#allRangesOfRegexMatches: regexString
+
+Returns a collection of all character ranges (startIndex to: stopIndex)
+that match the regular expression.
+
+	REPLACEMENT AND TRANSLATION
+
+It is possible to replace all matches of a regular expression with a
+certain string using the message:
+
+	#copyWithRegex: regexString matchesReplacedWith: aString
+
+For example:
+
+	'ab cd ab' copyWithRegex: '(a|b)+' matchesReplacedWith: 'foo'
+
+A more general substitution is match translation:
+
+	#copyWithRegex: regexString matchesTranslatedUsing: aBlock
+
+This message evaluates a block passing it each match of the regular
+expression in the receiver string and answers a copy of the receiver
+with the block results spliced into it in place of the respective
+matches.  For example:
+
+	'ab cd ab' copyWithRegex: '(a|b)+' matchesTranslatedUsing: [:each | each asUppercase]
+
+All messages of enumeration and replacement protocols perform a
+case-sensitive match.  Case-insensitive versions are not provided as
+part of a CharacterArray protocol.  Instead, they are accessible using
+the lower-level matching interface.
+
+	LOWER-LEVEL INTERFACE
+
+Internally, #matchesRegex: works as follows:
+
+1. A fresh instance of RxParser is created, and the regular expression
+string is passed to it, yielding the expression's syntax tree.
+
+2. The syntax tree is passed as an initialization parameter to an
+instance of RxMatcher. The instance sets up some data structure that
+will work as a recognizer for the regular expression described by the
+tree.
+
+3. The original string is passed to the matcher, and the matcher
+checks for a match.
+
+	THE MATCHER
+
+If you repeatedly match a number of strings against the same regular
+expression using one of the messages defined in CharacterArray, the
+regular expression string is parsed and a matcher is created anew for
+every match.  You can avoid this overhead by building a matcher for
+the regular expression, and then reusing the matcher over and over
+again. You can, for example, create a matcher at a class or instance
+initialization stage, and store it in a variable for future use.
+
+You can create a matcher using one of the following methods:
+
+	- Sending #forString:ignoreCase: message to RxMatcher class, with
+the regular expression string and a Boolean indicating whether case is
+ignored as arguments.
+
+	- Sending #forString: message.  It is equivalent to <... forString:
+regexString ignoreCase: false>.
+
+A more convenient way is using one of the two matcher-created messages
+understood by CharacterArray.
+
+	- <regexString asRegex> is equivalent to <RxMatcher forString:
+regexString>.
+
+	- <regexString asRegexIgnoringCase> is equivalent to <RxMatcher
+forString: regexString ignoreCase: true>.
+
+Here are four examples of creating a matcher:
+
+	hexRecognizer := RxMatcher forString: '16r[0-9A-Fa-f]+'
+	hexRecognizer := RxMatcher forString: '16r[0-9A-Fa-f]+' ignoreCase: false
+	hexRecognizer := '16r[0-9A-Fa-f]+' asRegex
+	hexRecognizer := '16r[0-9A-F]+' asRegexIgnoringCase
+
+	MATCHING
+
+The matcher understands these messages (all of them return true to
+indicate successful match or search, and false otherwise):
+
+matches: aString
+
+	True if the whole target string (aString) matches.
+
+matchesPrefix: aString
+
+	True if some prefix of the string (not necessarily the whole
+	string) matches.
+
+search: aString
+
+	Search the string for the first occurrence of a matching
+	substring. (Note that the first two methods only try matching from
+	the very beginning of the string). Using the above example with a
+	matcher for `a+', this method would answer success given a string
+	`baaa', while the previous two would fail.
+
+matchesStream: aStream
+matchesStreamPrefix: aStream
+searchStream: aStream
+
+	Respective analogs of the first three methods, taking input from a
+	stream instead of a string. The stream must be positionable and
+	peekable.
+
+All these methods answer a boolean indicating success. The matcher
+also stores the outcome of the last match attempt and can report it:
+
+lastResult
+
+	Answers a Boolean -- the outcome of the most recent match
+	attempt. If no matches were attempted, the answer is unspecified.
+
+	SUBEXPRESSION MATCHES
+
+After a successful match attempt, you can query the specifics of which
+part of the original string has matched which part of the whole
+expression.
+
+A subexpression is a parenthesized part of a regular expression, or
+the whole expression. When a regular expression is compiled, its
+subexpressions are assigned indices starting from 1, depth-first,
+left-to-right. For example, `((ab)+(c|d))?ef' includes the following
+subexpressions with these indices:
+
+	1:	((ab)+(c|d))?ef
+	2:	(ab)+(c|d)
+	3:	ab
+	4:	c|d
+
+After a successful match, the matcher can report what part of the
+original string matched what subexpression. It understandards these
+messages:
+
+subexpressionCount
+
+	Answers the total number of subexpressions: the highest value that
+	can be used as a subexpression index with this matcher. This value
+	is available immediately after initialization and never changes.
+
+subexpression: anIndex
+
+	An index must be a valid subexpression index, and this message
+	must be sent only after a successful match attempt. The method
+	answers a substring of the original string the corresponding
+	subexpression has matched to.
+
+subBeginning: anIndex
+subEnd: anIndex
+
+	Answer positions within the original string or stream where the
+	match of a subexpression with the given index has started and
+	ended, respectively.
+
+This facility provides a convenient way of extracting parts of input
+strings of complex format. For example, the following piece of code
+uses the 'MMM DD, YYYY' date format recognizer example from the
+`Syntax' section to convert a date to a three-element array with year,
+month, and day strings (you can select and evaluate it right here):
+
+	| matcher |
+	matcher := RxMatcher forString: '(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[ ]+(:isDigit::isDigit:?)[ ]*,[ ]*(19|20)(:isDigit::isDigit:)'.
+	(matcher matches: 'Aug 6, 1996')
+		ifTrue: 
+			[Array 
+				with: (matcher subexpression: 5)
+				with: (matcher subexpression: 2)
+				with: (matcher subexpression: 3)]
+		ifFalse: ['no match']
+
+(should answer ` #('96' 'Aug' '6')').
+
+	ENUMERATION AND REPLACEMENT
+
+The enumeration and replacement protocols exposed in CharacterArray
+are actually implemented by the matcher.  The following messages are
+understood:
+
+	#matchesIn: aString
+	#matchesIn: aString do: aBlock
+	#matchesIn: aString collect: aBlock
+	#copy: aString replacingMatchesWith: replacementString
+	#copy: aString translatingMatchesUsing: aBlock
+	#matchingRangesIn: aString
+
+	#matchesOnStream: aStream
+	#matchesOnStream: aStream do: aBlock
+	#matchesOnStream: aStream collect: aBlock
+	#copy: sourceStream to: targetStream replacingMatchesWith: replacementString
+	#copy: sourceStream to: targetStream translatingMatchesWith: aBlock
+
+Note that in those methods that take a block, the block may refer to the rxMatcher itself, 
+e.g. to collect information about the position the match occurred at, or the
+subexpressions of the match. An example can be seen in #matchingRangesIn:
+
+	ERROR HANDLING
+
+Exception signaling objects (Signals in VisualWorks, Exceptions in VisualAge) are
+accessible through RxParser class protocol. To handle possible errors, use
+the protocol described below to obtain the exception objects and use the
+protocol of the native Smalltalk implementation to handle them.
+
+If a syntax error is detected while parsing expression,
+RxParser>>syntaxErrorSignal is raised/signaled.
+
+If an error is detected while building a matcher,
+RxParser>>compilationErrorSignal is raised/signaled.
+
+If an error is detected while matching (for example, if a bad selector
+was specified using `:<selector>:' syntax, or because of the matcher's
+internal error), RxParser>>matchErrorSignal is raised
+
+RxParser>>regexErrorSignal is the parent of all three.  Since any of
+the three signals can be raised within a call to #matchesRegex:, it is
+handy if you want to catch them all.  For example:
+
+VisualWorks:
+
+	RxParser regexErrorSignal
+		handle: [:ex | ex returnWith: nil]
+		do: ['abc' matchesRegex: '))garbage[']
+
+VisualAge:
+
+	['abc' matchesRegex: '))garbage[']
+		when: RxParser regexErrorSignal
+		do: [:signal | signal exitWith: nil]
+
+"
+
+	self error: 'comment only'! !
+
+!RxParser class methodsFor: 'exception signaling' stamp: 'lr 11/4/2009 22:37'!
+doHandlingMessageNotUnderstood: aBlock
+	"MNU should be trapped and resignaled as a match error in a few places in the matcher.
+	This method factors out this dialect-dependent code to make porting easier."
+	^ aBlock
+		on: MessageNotUnderstood
+		do: [:ex | RxParser signalMatchException: 'invalid predicate selector']! !
+
+!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'vb 4/11/09 21:56'!
+e: x implementationNotes: xx
+"	
+	Version:		1.1
+	Released:		October 1999
+	Mail to:		Vassili Bykov <vassili@parcplace.com>, <v_bykov@yahoo.com>
+	Flames to:		/dev/null
+
+	WHAT IS ADDED
+
+The matcher includes classes in two categories:
+	VB-Regex-Syntax
+	VB-Regex-Matcher
+and a few CharacterArray methods in `VB-regex' protocol.  No system
+classes or methods are modified.
+
+	WHAT TO LOOK AT FIRST
+
+String>>matchesRegex: -- in 90% cases this method is all you need to
+access the package.
+
+RxParser -- accepts a string or a stream of characters with a regular
+expression, and produces a syntax tree corresponding to the
+expression. The tree is made of instances of Rxs<whatever> classes.
+
+RxMatcher -- accepts a syntax tree of a regular expression built by
+the parser and compiles it into a matcher: a structure made of
+instances of Rxm<whatever> classes. The RxMatcher instance can test
+whether a string or a positionable stream of characters matches the
+original regular expression, or search a string or a stream for
+substrings matching the expression. After a match is found, the
+matcher can report a specific string that matched the whole
+expression, or any parenthesized subexpression of it.
+
+All other classes support the above functionality and are used by
+RxParser, RxMatcher, or both.
+
+	CAVEATS
+
+The matcher is similar in spirit, but NOT in the design--let alone the
+code--to the original Henry Spencer's regular expression
+implementation in C.  The focus is on simplicity, not on efficiency.
+I didn't optimize or profile anything.  I may in future--or I may not:
+I do this in my spare time and I don't promise anything.
+
+The matcher passes H. Spencer's test suite (see 'test suite'
+protocol), with quite a few extra tests added, so chances are good
+there are not too many bugs.  But watch out anyway.
+
+	EXTENSIONS, FUTURE, ETC.
+
+With the existing separation between the parser, the syntax tree, and
+the matcher, it is easy to extend the system with other matchers based
+on other algorithms. In fact, I have a DFA-based matcher right now,
+but I don't feel it is good enough to include it here.  I might add
+automata-based matchers later, but again I don't promise anything.
+
+	HOW TO REACH ME
+
+As of today (December 20, 2000), you can contact me at
+<vassili@parcplace.com>. If this doesn't work, look around
+comp.lang.smalltalk or comp.lang.lisp.  
+"
+
+	self error: 'comment only'! !
+
+!RxParser class methodsFor: 'DOCUMENTATION' stamp: 'vb 4/11/09 21:56'!
+f: x boringStuff: xx
+"
+The Regular Expression Matcher (``The Software'') 
+is Copyright (C) 1996, 1999 Vassili Bykov.  
+It is provided to the Smalltalk community in hope it will be useful.
+
+1. This license applies to the package as a whole, as well as to any
+   component of it. By performing any of the activities described
+   below, you accept the terms of this agreement.
+
+2. The software is provided free of charge, and ``as is'', in hope
+   that it will be useful, with ABSOLUTELY NO WARRANTY. The entire
+   risk and all responsibility for the use of the software is with
+   you.  Under no circumstances the author may be held responsible for
+   loss of data, loss of profit, or any other damage resulting
+   directly or indirectly from the use of the software, even if the
+   damage is caused by defects in the software.
+
+3. You may use this software in any applications you build.
+
+4. You may distribute this software provided that the software
+   documentation and copyright notices are included and intact.
+
+5. You may create and distribute modified versions of the software,
+   such as ports to other Smalltalk dialects or derived work, provided
+   that: 
+
+   a. any modified version is expressly marked as such and is not
+   misrepresented as the original software; 
+
+   b. credit is given to the original software in the source code and
+   documentation of the derived work; 
+
+   c. the copyright notice at the top of this document accompanies
+   copyright notices of any modified version.  "
+
+	self error: 'comment only'! !
+
+!RxParser class methodsFor: 'class initialization' stamp: 'avi 11/30/2003 13:26'!
+initialize
+	"self initialize"
+	self
+		initializeBackslashConstants;
+		initializeBackslashSpecials! !
+
+!RxParser class methodsFor: 'class initialization' stamp: 'lr 11/4/2009 22:14'!
+initializeBackslashConstants
+	"self initializeBackslashConstants"
+
+	(BackslashConstants := Dictionary new)
+		at: $e put: Character escape;
+		at: $n put: Character lf;
+		at: $r put: Character cr;
+		at: $f put: Character newPage;
+		at: $t put: Character tab! !
+
+!RxParser class methodsFor: 'class initialization' stamp: 'vb 4/11/09 21:56'!
+initializeBackslashSpecials
+	"Keys are characters that normally follow a \, the values are
+	associations of classes and initialization selectors on the instance side
+	of the classes."
+	"self initializeBackslashSpecials"
+
+	(BackslashSpecials := Dictionary new)
+		at: $w put: (Association key: RxsPredicate value: #beWordConstituent);
+		at: $W put: (Association key: RxsPredicate value: #beNotWordConstituent);
+		at: $s put: (Association key: RxsPredicate value: #beSpace);
+		at: $S put: (Association key: RxsPredicate value: #beNotSpace);
+		at: $d put: (Association key: RxsPredicate value: #beDigit);
+		at: $D put: (Association key: RxsPredicate value: #beNotDigit);
+		at: $b put: (Association key: RxsContextCondition value: #beWordBoundary);
+		at: $B put: (Association key: RxsContextCondition value: #beNonWordBoundary);
+		at: $< put: (Association key: RxsContextCondition value: #beBeginningOfWord);
+		at: $> put: (Association key: RxsContextCondition value: #beEndOfWord)! !
+
+!RxParser class methodsFor: 'utilities' stamp: 'vb 4/11/09 21:56'!
+parse: aString
+	"Parse the argument and return the result (the parse tree).
+	In case of a syntax error, the corresponding exception is signaled."
+
+	^self new parse: aString! !
+
+!RxParser class methodsFor: 'preferences' stamp: 'vb 4/11/09 21:56'!
+preferredMatcherClass
+	"The matcher to use. For now just one is available, but in
+	principle this determines the matchers built implicitly,
+	such as by String>>asRegex, or String>>matchesRegex:.
+	This might seem a bit strange place for this preference, but
+	Parser is still more or less `central' thing in the whole package."
+
+	^RxMatcher! !
+
+!RxParser class methodsFor: 'utilities' stamp: 'avi 11/30/2003 13:23'!
+safelyParse: aString
+	"Parse the argument and return the result (the parse tree).
+	In case of a syntax error, return nil.
+	Exception handling here is dialect-dependent."
+	^ [self new parse: aString] on: RegexSyntaxError do: [:ex | nil]! !
+
+!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
+signalCompilationException: errorString
+	RegexCompilationError new signal: errorString! !
+
+!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
+signalMatchException: errorString
+	RegexMatchingError new signal: errorString! !
+
+!RxParser class methodsFor: 'exception signaling' stamp: 'avi 11/30/2003 13:25'!
+signalSyntaxException: errorString
+	RegexSyntaxError new signal: errorString! !
+
+!RxmLink methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
+matchAgainst: aMatcher
+	"If a link does not match the contents of the matcher's stream,
+	answer false. Otherwise, let the next matcher in the chain match."
+
+	^next matchAgainst: aMatcher! !
+
+!RxmLink methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
+next
+	
+	^next! !
+
+!RxmLink methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+next: aLink
+	"Set the next link, either an RxmLink or an RxmTerminator."
+
+	next := aLink! !
+
+!RxmLink methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
+pointTailTo: anRxmLink
+	"Propagate this message along the chain of links.
+	Point `next' reference of the last link to <anRxmLink>.
+	If the chain is already terminated, blow up."
+
+	next == nil
+		ifTrue: [next := anRxmLink]
+		ifFalse: [next pointTailTo: anRxmLink]! !
+
+!RxmLink methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
+terminateWith: aTerminator
+	"Propagate this message along the chain of links, and
+	make aTerminator the `next' link of the last link in the chain.
+	If the chain is already reminated with the same terminator, 
+	do not blow up."
+
+	next == nil
+		ifTrue: [next := aTerminator]
+		ifFalse: [next terminateWith: aTerminator]! !
+
+!RxmBranch methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+alternative: aBranch
+	"See class comment for instance variable description."
+
+	alternative := aBranch! !
+
+!RxmBranch methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beLoopback
+	"See class comment for instance variable description."
+
+	loopback := true! !
+
+!RxmBranch methodsFor: 'initialize-release' stamp: 'lr 11/4/2009 22:38'!
+initialize
+	"See class comment for instance variable description."
+
+	super initialize.
+	loopback := false! !
+
+!RxmBranch methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
+matchAgainst: aMatcher
+	"Match either `next' or `alternative'. Fail if the alternative is nil."
+
+	^(next matchAgainst: aMatcher)
+		or: [alternative notNil
+			and: [alternative matchAgainst: aMatcher]]! !
+
+!RxmBranch methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
+pointTailTo: aNode
+	"See superclass for explanations."
+
+	loopback
+		ifTrue: [alternative == nil
+			ifTrue: [alternative := aNode]
+			ifFalse: [alternative pointTailTo: aNode]]
+		ifFalse: [super pointTailTo: aNode]! !
+
+!RxmBranch methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
+terminateWith: aNode
+	"See superclass for explanations."
+
+	loopback
+		ifTrue: [alternative == nil
+			ifTrue: [alternative := aNode]
+			ifFalse: [alternative terminateWith: aNode]]
+		ifFalse: [super terminateWith: aNode]! !
+
+!RxmMarker methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+index: anIndex
+	"An index is a key that makes sense for the matcher.
+	This key can be passed to marker position getters and
+	setters to access position for this marker in the current
+	matching session."
+
+	index := anIndex! !
+
+!RxmMarker methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
+matchAgainst: aMatcher
+	"If the rest of the link chain matches successfully, report the
+	position of the stream *before* the match started to the matcher."
+
+	| startPosition |
+	startPosition := aMatcher position.
+	(next matchAgainst: aMatcher)
+		ifTrue:
+			[aMatcher markerPositionAt: index add: startPosition.
+			^true].
+	^false! !
+
+!RxmPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+bePerform: aSelector
+	"Match any single character that answers true  to this message."
+
+	self predicate: 
+		[:char | 
+		RxParser doHandlingMessageNotUnderstood: [char perform: aSelector]]! !
+
+!RxmPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+bePerformNot: aSelector
+	"Match any single character that answers false to this message."
+
+	self predicate: 
+		[:char | 
+		RxParser doHandlingMessageNotUnderstood: [(char perform: aSelector) not]]! !
+
+!RxmPredicate methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
+matchAgainst: aMatcher
+	"Match if the predicate block evaluates to true when given the
+	current stream character as the argument."
+
+	| original |
+	original := aMatcher currentState.
+	(aMatcher atEnd not 
+		and: [(predicate value: aMatcher next)
+			and: [next matchAgainst: aMatcher]])
+		ifTrue: [^true]
+		ifFalse:
+			[aMatcher restoreState: original.
+			^false]! !
+
+!RxmPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+predicate: aBlock
+	"This link will match any single character for which <aBlock>
+	evaluates to true."
+
+	aBlock numArgs ~= 1 ifTrue: [self error: 'bad predicate block'].
+	predicate := aBlock.
+	^self! !
+
+!RxmPredicate class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
+with: unaryBlock
+
+	^self new predicate: unaryBlock! !
+
+!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beBeginningOfLine
+
+	matchSelector := #atBeginningOfLine! !
+
+!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beBeginningOfWord
+
+	matchSelector := #atBeginningOfWord! !
+
+!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beEndOfLine
+
+	matchSelector := #atEndOfLine! !
+
+!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beEndOfWord
+
+	matchSelector := #atEndOfWord! !
+
+!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beNotWordBoundary
+
+	matchSelector := #notAtWordBoundary! !
+
+!RxmSpecial methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beWordBoundary
+
+	matchSelector := #atWordBoundary! !
+
+!RxmSpecial methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
+matchAgainst: aMatcher
+	"Match without consuming any input, if the matcher is
+	in appropriate state."
+
+	^(aMatcher perform: matchSelector)
+		and: [next matchAgainst: aMatcher]! !
+
+!RxmSubstring methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beCaseInsensitive
+
+	compare := [:char1 :char2 | char1 sameAs: char2]! !
+
+!RxmSubstring methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beCaseSensitive
+
+	compare := [:char1 :char2 | char1 = char2]! !
+
+!RxmSubstring methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+character: aCharacter ignoreCase: aBoolean
+	"Match exactly this character."
+
+	sample := String with: aCharacter.
+	aBoolean ifTrue: [self beCaseInsensitive]! !
+
+!RxmSubstring methodsFor: 'initialize-release' stamp: 'lr 11/4/2009 22:38'!
+initialize
+	super initialize.
+	self beCaseSensitive! !
+
+!RxmSubstring methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
+matchAgainst: aMatcher
+	"Match if my sample stream is exactly the current prefix
+	of the matcher stream's contents."
+
+	| originalState sampleStream mismatch |
+	originalState := aMatcher currentState.
+	sampleStream := self sampleStream.
+	mismatch := false.
+	[sampleStream atEnd
+		or: [aMatcher atEnd
+		or: [mismatch := (compare value: sampleStream next value: aMatcher next) not]]] whileFalse.
+	(mismatch not and: [sampleStream atEnd and: [next matchAgainst: aMatcher]])
+		ifTrue: [^true]
+		ifFalse: 
+			[aMatcher restoreState: originalState.
+			^false]! !
+
+!RxmSubstring methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+sampleStream
+
+	^sample readStream! !
+
+!RxmSubstring methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+substring: aString ignoreCase: aBoolean
+	"Match exactly this string."
+
+	sample := aString.
+	aBoolean ifTrue: [self beCaseInsensitive]! !
+
+!RxmTerminator methodsFor: 'matching' stamp: 'vb 4/11/09 21:56'!
+matchAgainst: aStream
+	"If got here, the match is successful."
+
+	^true! !
+
+!RxmTerminator methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
+pointTailTo: anRxmLink
+	"Branch tails are never redirected by the build algorithm.
+	Healthy terminators should never receive this."
+
+	RxParser signalCompilationException:
+		'internal matcher build error - redirecting terminator tail'! !
+
+!RxmTerminator methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
+terminateWith: aTerminator
+	"Branch terminators are never supposed to change.
+	Make sure this is the case."
+
+	aTerminator ~~ self
+		ifTrue: [RxParser signalCompilationException:
+				'internal matcher build error - wrong terminator']! !
+
+!RxsNode methodsFor: 'constants' stamp: 'vb 4/11/09 21:56'!
+indentCharacter
+	"Normally, #printOn:withIndent: method in subclasses
+	print several characters returned by this method to indicate
+	the tree structure."
+
+	^$+! !
+
+!RxsNode methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isAtomic
+	"Answer whether the node is atomic, i.e. matches exactly one 
+	constant predefined normal character.  A matcher may decide to 
+	optimize matching of a sequence of atomic nodes by glueing them 
+	together in a string."
+
+	^false "tentatively"! !
+
+!RxsNode methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isNullable
+	"True if the node can match an empty sequence of characters."
+
+	^false "for most nodes"! !
+
+!RxsBranch methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+branch
+
+	^branch! !
+
+!RxsBranch methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+dispatchTo: aMatcher
+	"Inform the matcher of the kind of the node, and it
+	will do whatever it has to."
+
+	^aMatcher syntaxBranch: self! !
+
+!RxsBranch methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializePiece: aPiece branch: aBranch
+	"See class comment for instance variables description."
+
+	piece := aPiece.
+	branch := aBranch! !
+
+!RxsBranch methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isNullable
+
+	^piece isNullable and: [branch isNil or: [branch isNullable]]! !
+
+!RxsBranch methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+piece
+
+	^piece! !
+
+!RxsBranch methodsFor: 'optimization' stamp: 'vb 4/11/09 21:56'!
+tryMergingInto: aStream
+	"Concatenation of a few simple characters can be optimized
+	to be a plain substring match. Answer the node to resume
+	syntax tree traversal at. Epsilon node used to terminate the branch
+	will implement this to answer nil, thus indicating that the branch
+	has ended."
+
+	piece isAtomic ifFalse: [^self].
+	aStream nextPut: piece character.
+	^branch isNil
+		ifTrue: [branch]
+		ifFalse: [branch tryMergingInto: aStream]! !
+
+!RxsCharSet methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+dispatchTo: aMatcher
+	"Inform the matcher of the kind of the node, and it
+	will do whatever it has to."
+
+	^aMatcher syntaxCharSet: self! !
+
+!RxsCharSet methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
+enumerablePartPredicateIgnoringCase: aBoolean
+
+	| enumeration |
+	enumeration := self optimalSetIgnoringCase: aBoolean.
+	^negated
+		ifTrue: [[:char | (enumeration includes: char) not]]
+		ifFalse: [[:char | enumeration includes: char]]! !
+
+!RxsCharSet methodsFor: 'privileged' stamp: 'vb 4/11/09 21:56'!
+enumerableSetIgnoringCase: aBoolean
+	"Answer a collection of characters that make up the portion of me
+	that can be enumerated."
+
+	| set |
+	set := Set new.
+	elements do:
+		[:each |
+		each isEnumerable ifTrue:
+			[each enumerateTo: set ignoringCase: aBoolean]].
+	^set! !
+
+!RxsCharSet methodsFor: 'accessing' stamp: 'KenD 11/22/2016 13:09:30'!
+hasPredicates
+
+	^elements includes: [:some | some isEnumerable not]! !
+
+!RxsCharSet methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializeElements: aCollection negated: aBoolean
+	"See class comment for instance variables description."
+
+	elements := aCollection.
+	negated := aBoolean! !
+
+!RxsCharSet methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isEnumerable
+
+	elements detect: [:some | some isEnumerable not] ifNone: [^true].
+	^false! !
+
+!RxsCharSet methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isNegated
+
+	^negated! !
+
+!RxsCharSet methodsFor: 'privileged' stamp: 'lr 11/4/2009 22:27'!
+optimalSetIgnoringCase: aBoolean
+	"Assuming the client with search the `set' using #includes:,
+	answer a collection with the contents of `set', of the class
+	that will provide the fastest lookup. Strings are faster than
+	Sets for short strings."
+
+	| set |
+	set := self enumerableSetIgnoringCase: aBoolean.
+	^set size < 10
+		ifTrue: [set asArray]
+		ifFalse: [set]! !
+
+!RxsCharSet methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+predicateIgnoringCase: aBoolean
+
+	| predicate enumerable |
+	enumerable := self enumerablePartPredicateIgnoringCase: aBoolean.
+	^self hasPredicates
+		ifFalse: [enumerable]
+		ifTrue:
+			[predicate := self predicatePartPredicate.
+			negated
+				ifTrue: [[:char | (enumerable value: char) and: [predicate value: char]]]
+				ifFalse: [[:char | (enumerable value: char) or: [predicate value: char]]]]! !
+
+!RxsCharSet methodsFor: 'privileged' stamp: 'KenD 11/22/2016 13:09:41'!
+predicatePartPredicate
+	"Answer a predicate that tests all of my elements that cannot be
+	enumerated."
+
+	| predicates |
+	predicates := elements reject: [:some | some isEnumerable].
+	predicates isEmpty
+		ifTrue: [^[:char | negated]].
+	predicates size = 1
+		ifTrue: [^negated
+			ifTrue: [predicates first predicateNegation]
+			ifFalse: [predicates first predicate]].
+	predicates := predicates collect: [:each | each predicate].
+	^negated
+		ifFalse:
+			[[:char | predicates includes: [:some | some value: char]]]
+		ifTrue:
+			[[:char | (predicates includes: [:some | some value: char]) not]]! !
+
+!RxsCharSet methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+predicates
+
+	^(elements reject: [:some | some isEnumerable])
+		collect: [:each | each predicate]! !
+
+!RxsCharacter methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+character
+
+	^character! !
+
+!RxsCharacter methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+dispatchTo: aMatcher
+	"Inform the matcher of the kind of the node, and it
+	will do whatever it has to."
+
+	^aMatcher syntaxCharacter: self! !
+
+!RxsCharacter methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+enumerateTo: aSet ignoringCase: aBoolean
+
+	aBoolean
+		ifTrue: 
+			[aSet 
+				add: character asUppercase;
+				add: character asLowercase]
+		ifFalse: [aSet add: character]! !
+
+!RxsCharacter methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializeCharacter: aCharacter
+	"See class comment for instance variable description."
+
+	character := aCharacter! !
+
+!RxsCharacter methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isAtomic
+	"A character is always atomic."
+
+	^true! !
+
+!RxsCharacter methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isEnumerable
+
+	^true! !
+
+!RxsCharacter methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isNullable
+
+	^false! !
+
+!RxsCharacter class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
+with: aCharacter
+
+	^self new initializeCharacter: aCharacter! !
+
+!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beAny
+	"Matches anything but a newline."
+
+	kind := #syntaxAny! !
+
+!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beBeginningOfLine
+	"Matches empty string at the beginning of a line."
+
+	kind := #syntaxBeginningOfLine! !
+
+!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beBeginningOfWord
+	"Matches empty string at the beginning of a word."
+
+	kind := #syntaxBeginningOfWord! !
+
+!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beEndOfLine
+	"Matches empty string at the end of a line."
+
+	kind := #syntaxEndOfLine! !
+
+!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beEndOfWord
+	"Matches empty string at the end of a word."
+
+	kind := #syntaxEndOfWord! !
+
+!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beNonWordBoundary
+	"Analog of \B."
+
+	kind := #syntaxNonWordBoundary! !
+
+!RxsContextCondition methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beWordBoundary
+	"Analog of \w (alphanumeric plus _)."
+
+	kind := #syntaxWordBoundary! !
+
+!RxsContextCondition methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+dispatchTo: aBuilder
+
+	^aBuilder perform: kind! !
+
+!RxsContextCondition methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isNullable
+
+	^#syntaxAny ~~ kind! !
+
+!RxsEpsilon methodsFor: 'building' stamp: 'vb 4/11/09 21:56'!
+dispatchTo: aBuilder
+	"Inform the matcher of the kind of the node, and it
+	will do whatever it has to."
+
+	^aBuilder syntaxEpsilon! !
+
+!RxsEpsilon methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isNullable
+	"See comment in the superclass."
+
+	^true! !
+
+!RxsMessagePredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+dispatchTo: aBuilder
+	"Inform the matcher of the kind of the node, and it
+	will do whatever it has to."
+
+	^aBuilder syntaxMessagePredicate: self! !
+
+!RxsMessagePredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializeSelector: aSelector
+	"The selector must be a one-argument message understood by Character."
+
+	selector := aSelector! !
+
+!RxsMessagePredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializeSelector: aSelector negated: aBoolean
+	"The selector must be a one-argument message understood by Character."
+
+	selector := aSelector.
+	negated := aBoolean! !
+
+!RxsMessagePredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+negated
+
+	^negated! !
+
+!RxsMessagePredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+selector
+
+	^selector! !
+
+!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+atom
+
+	^atom! !
+
+!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+character
+	"If this node is atomic, answer the character it
+	represents. It is the caller's responsibility to make sure this
+	node is indeed atomic before using this."
+
+	^atom character! !
+
+!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+dispatchTo: aMatcher
+	"Inform the matcher of the kind of the node, and it
+	will do whatever it has to."
+
+	^aMatcher syntaxPiece: self! !
+
+!RxsPiece methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializeAtom: anAtom
+	"This piece is exactly one occurrence of the specified RxsAtom."
+
+	self initializeAtom: anAtom min: 1 max: 1! !
+
+!RxsPiece methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializeAtom: anAtom min: minOccurrences max: maxOccurrences
+	"This piece is from <minOccurrences> to <maxOccurrences> 
+	occurrences of the specified RxsAtom."
+
+	atom := anAtom.
+	min := minOccurrences.
+	max := maxOccurrences! !
+
+!RxsPiece methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializeOptionalAtom: anAtom
+	"This piece is 0 or 1 occurrences of the specified RxsAtom."
+
+	self initializeAtom: anAtom min: 0 max: 1! !
+
+!RxsPiece methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializePlusAtom: anAtom
+	"This piece is one or more occurrences of the specified RxsAtom."
+
+	self initializeAtom: anAtom min: 1 max: nil! !
+
+!RxsPiece methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializeStarAtom: anAtom
+	"This piece is any number of occurrences of the atom."
+
+	self initializeAtom: anAtom min: 0 max: nil! !
+
+!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isAtomic
+	"A piece is atomic if only it contains exactly one atom
+	which is atomic (sic)."
+
+	^self isSingular and: [atom isAtomic]! !
+
+!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isNullable
+	"A piece is nullable if it allows 0 matches. 
+	This is often handy to know for optimization."
+
+	^min = 0 or: [atom isNullable]! !
+
+!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isOptional
+
+	^min = 0 and: [max = 1]! !
+
+!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isPlus
+
+	^min = 1 and: [max == nil]! !
+
+!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isSingular
+	"A piece with a range is 1 to 1 needs can be compiled
+	as a simple match."
+
+	^min = 1 and: [max = 1]! !
+
+!RxsPiece methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isStar
+
+	^min = 0 and: [max == nil]! !
+
+!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+max
+	"The value answered may be nil, indicating infinity."
+
+	^max! !
+
+!RxsPiece methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+min
+
+	^min! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beAlphaNumeric
+
+	predicate := [:char | char isAlphaNumeric].
+	negation := [:char | char isAlphaNumeric not]! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'lr 11/4/2009 22:29'!
+beAlphabetic
+
+	predicate := [:char | char isLetter].
+	negation := [:char | char isLetter not]! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beBackslash
+
+	predicate := [:char | char == $\].
+	negation := [:char | char ~~ $\]! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beControl
+
+	predicate := [:char | char asInteger < 32].
+	negation := [:char | char asInteger >= 32]! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beDigit
+
+	predicate := [:char | char isDigit].
+	negation := [:char | char isDigit not]! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beGraphics
+
+	self
+		beControl;
+		negate! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beHexDigit
+
+	| hexLetters |
+	hexLetters := 'abcdefABCDEF'.
+	predicate := [:char | char isDigit or: [hexLetters includes: char]].
+	negation := [:char | char isDigit not and: [(hexLetters includes: char) not]]! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beLowercase
+
+	predicate := [:char | char isLowercase].
+	negation := [:char | char isLowercase not]! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beNotDigit
+
+	self
+		beDigit;
+		negate! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beNotSpace
+
+	self
+		beSpace;
+		negate! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beNotWordConstituent
+
+	self
+		beWordConstituent;
+		negate! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+bePrintable
+
+	self
+		beControl;
+		negate! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+bePunctuation
+
+	| punctuationChars |
+	punctuationChars := #($. $, $!! $? $; $: $" $' $- $( $) $`).
+	predicate := [:char | punctuationChars includes: char].
+	negation := [:char | (punctuationChars includes: char) not]! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beSpace
+
+	predicate := [:char | char isSeparator].
+	negation := [:char | char isSeparator not]! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+beUppercase
+
+	predicate := [:char | char isUppercase].
+	negation := [:char | char isUppercase not]! !
+
+!RxsPredicate methodsFor: 'initialize-release' stamp: 'lr 1/7/2010 20:06'!
+beWordConstituent
+
+	predicate := [:char | char isAlphaNumeric or: [char == $_]].
+	negation := [:char | char isAlphaNumeric not and: [char ~~ $_]]! !
+
+!RxsPredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+dispatchTo: anObject
+
+	^anObject syntaxPredicate: self! !
+
+!RxsPredicate methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isAtomic
+	"A predicate is a single character but the character is not known in advance."
+
+	^false! !
+
+!RxsPredicate methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isEnumerable
+
+	^false! !
+
+!RxsPredicate methodsFor: 'private' stamp: 'vb 4/11/09 21:56'!
+negate
+
+	| tmp |
+	tmp := predicate.
+	predicate := negation.
+	negation := tmp! !
+
+!RxsPredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+negated
+
+	^self copy negate! !
+
+!RxsPredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+predicate
+
+	^predicate! !
+
+!RxsPredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+predicateNegation
+
+	^negation! !
+
+!RxsPredicate methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+value: aCharacter
+
+	^predicate value: aCharacter! !
+
+!RxsPredicate class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
+forEscapedLetter: aCharacter
+
+	^self new perform:
+		(EscapedLetterSelectors
+			at: aCharacter
+			ifAbsent: [RxParser signalSyntaxException: 'bad backslash escape'])! !
+
+!RxsPredicate class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
+forNamedClass: aString
+
+	^self new perform:
+		(NamedClassSelectors
+			at: aString
+			ifAbsent: [RxParser signalSyntaxException: 'bad character class name'])! !
+
+!RxsPredicate class methodsFor: 'class initialization' stamp: 'vb 4/11/09 21:56'!
+initialize
+	"self initialize"
+
+	self
+		initializeNamedClassSelectors;
+		initializeEscapedLetterSelectors! !
+
+!RxsPredicate class methodsFor: 'class initialization' stamp: 'vb 4/11/09 21:56'!
+initializeEscapedLetterSelectors
+	"self initializeEscapedLetterSelectors"
+
+	(EscapedLetterSelectors := Dictionary new)
+		at: $w put: #beWordConstituent;
+		at: $W put: #beNotWordConstituent;
+		at: $d put: #beDigit;
+		at: $D put: #beNotDigit;
+		at: $s put: #beSpace;
+		at: $S put: #beNotSpace;
+		at: $\ put: #beBackslash! !
+
+!RxsPredicate class methodsFor: 'class initialization' stamp: 'vb 4/11/09 21:56'!
+initializeNamedClassSelectors
+	"self initializeNamedClassSelectors"
+
+	(NamedClassSelectors := Dictionary new)
+		at: 'alnum' put: #beAlphaNumeric;
+		at: 'alpha' put: #beAlphabetic;
+		at: 'cntrl' put: #beControl;
+		at: 'digit' put: #beDigit;
+		at: 'graph' put: #beGraphics;
+		at: 'lower' put: #beLowercase;
+		at: 'print' put: #bePrintable;
+		at: 'punct' put: #bePunctuation;
+		at: 'space' put: #beSpace;
+		at: 'upper' put: #beUppercase;
+		at: 'xdigit' put: #beHexDigit! !
+
+!RxsRange methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+enumerateTo: aSet ignoringCase: aBoolean
+	"Add all of the elements I represent to the collection."
+
+	first asInteger to: last asInteger do:
+		[:charCode | | character |
+		character := charCode asCharacter.
+		aBoolean
+		ifTrue: 
+			[aSet 
+				add: character asUppercase;
+				add: character asLowercase]
+		ifFalse: [aSet add: character]]! !
+
+!RxsRange methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializeFirst: aCharacter last: anotherCharacter
+
+	first := aCharacter.
+	last := anotherCharacter! !
+
+!RxsRange methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isEnumerable
+
+	^true! !
+
+!RxsRange class methodsFor: 'instance creation' stamp: 'vb 4/11/09 21:56'!
+from: aCharacter to: anotherCharacter
+
+	^self new initializeFirst: aCharacter last: anotherCharacter! !
+
+!RxsRegex methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+branch
+
+	^branch! !
+
+!RxsRegex methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+dispatchTo: aMatcher
+	"Inform the matcher of the kind of the node, and it
+	will do whatever it has to."
+
+	^aMatcher syntaxRegex: self! !
+
+!RxsRegex methodsFor: 'initialize-release' stamp: 'vb 4/11/09 21:56'!
+initializeBranch: aBranch regex: aRegex
+	"See class comment for instance variable description."
+
+	branch := aBranch.
+	regex := aRegex! !
+
+!RxsRegex methodsFor: 'testing' stamp: 'vb 4/11/09 21:56'!
+isNullable
+
+	^branch isNullable or: [regex notNil and: [regex isNullable]]! !
+
+!RxsRegex methodsFor: 'accessing' stamp: 'vb 4/11/09 21:56'!
+regex
+	^regex! !
 RxMatcher initialize!
 RxParser initialize!
 RxsPredicate initialize!

--- a/Regex-Tests.pck.st
+++ b/Regex-Tests.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 5.0 of 7 November 2016 [latest update: #2974] on 22 November 2016 at 1:04:01 pm'!
+'From Cuis 5.0 of 7 November 2016 [latest update: #2984] on 25 November 2016 at 1:39:36 pm'!
 'Description Please enter a description for this package '!
-!provides: 'RegEx-Tests' 1 1!
+!provides: 'RegEx-Tests' 1 2!
 !requires: 'RegEx-Core' 1 1 nil!
 !classDefinition: #RxMatcherTest category: #'RegEx-Tests-Core'!
 TestCase subclass: #RxMatcherTest
@@ -1021,6 +1021,16 @@ testRegex004
 	self runRegex: #(':isVowel:'
 		'aei' true nil
 		'xyz' false nil)! !
+
+!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'KenD 11/25/2016 13:39:02'!
+testRemoveHTMLTags
+	"Remove HTML Tags"
+	
+	| regex html |
+	regex := '</?[0-9A-Za-z]+[^>]*>' asRegex.
+	html := '<a>foo<b>bar</b></a>'.
+	self assert: (regex copy: html replacingMatchesWith: '') = 'foobar'
+! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'gsa 12/22/2012 12:26'!
 testStringAllRangesOfRegexMatches

--- a/Regex-Tests.pck.st
+++ b/Regex-Tests.pck.st
@@ -1,7 +1,7 @@
 'From Cuis 5.0 of 7 November 2016 [latest update: #2984] on 25 November 2016 at 1:39:36 pm'!
 'Description Please enter a description for this package '!
-!provides: 'RegEx-Tests' 1 2!
-!requires: 'RegEx-Core' 1 1 nil!
+!provides: 'Regex-Tests' 1 2!
+!requires: 'Regex-Core' 1 1 nil!
 !classDefinition: #RxMatcherTest category: #'RegEx-Tests-Core'!
 TestCase subclass: #RxMatcherTest
 	instanceVariableNames: ''

--- a/Regex-Tests.pck.st
+++ b/Regex-Tests.pck.st
@@ -1,7 +1,10 @@
-'From Cuis 5.0 of 7 November 2016 [latest update: #2984] on 25 November 2016 at 1:39:36 pm'!
+'From Cuis 5.0 [latest update: #4360] on 5 October 2020 at 12:52:28 pm'!
 'Description Please enter a description for this package '!
-!provides: 'Regex-Tests' 1 2!
+!provides: 'Regex-Tests' 1 3!
 !requires: 'Regex-Core' 1 1 nil!
+SystemOrganization addCategory: #'RegEx-Tests-Core'!
+
+
 !classDefinition: #RxMatcherTest category: #'RegEx-Tests-Core'!
 TestCase subclass: #RxMatcherTest
 	instanceVariableNames: ''
@@ -29,6 +32,10 @@ This class provides tests for the regular expression matcher.!
 !RxParserTest commentStamp: 'Tbn 11/12/2010 22:31' prior: 0!
 This class provides tests for the regular expression parser.!
 
+!RxMatcherTest methodsFor: 'accessing' stamp: 'lr 1/15/2010 19:39'!
+parserClass
+	^ RxParser! !
+
 !RxMatcherTest methodsFor: 'utilties' stamp: 'TestRunner 1/15/2010 19:38'!
 compileRegex: aString
 	"Compile the regex and answer the matcher, or answer nil if compilation fails."
@@ -36,18 +43,6 @@ compileRegex: aString
 	| syntaxTree |
 	syntaxTree := self parserClass safelyParse: aString.
 	^ syntaxTree isNil ifFalse: [ self matcherClass for: syntaxTree ]! !
-
-!RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-henryReadme
-	self error: 'The tests in this category are based on the ones in Henry Spencer''s regexp.c package.'! !
-
-!RxMatcherTest methodsFor: 'accessing' stamp: 'gsa 12/22/2012 12:25'!
-matcherClass
-	^ RxMatcher! !
-
-!RxMatcherTest methodsFor: 'accessing' stamp: 'lr 1/15/2010 19:39'!
-parserClass
-	^ RxParser! !
 
 !RxMatcherTest methodsFor: 'utilties' stamp: 'gsa 12/22/2012 12:26'!
 runMatcher: aMatcher with: aString expect: aBoolean withSubexpressions: anArray
@@ -95,93 +90,9 @@ runRegex: anArray
 							expect: (anArray at: index + 1)
 							withSubexpressions: (anArray at: index + 2) ] ] ]! !
 
-!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:28'!
-testCaseInsensitive
-	| matcher |
-	matcher := self matcherClass forString: 'the quick brown fox' ignoreCase: true.
-	self assert: (matcher search: 'the quick brown fox').
-	self assert: (matcher search: 'The quick brown FOX').
-	self assert: (matcher search: 'What do you know about the quick brown fox?').
-	self assert: (matcher search: 'What do you know about THE QUICK BROWN FOX?')! !
-
-!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:28'!
-testCaseSensitive
-	| matcher |
-	matcher := self matcherClass forString: 'the quick brown fox' ignoreCase: false.
-	self assert: (matcher search: 'the quick brown fox').
-	self deny: (matcher search: 'The quick brown FOX').
-	self assert: (matcher search: 'What do you know about the quick brown fox?').
-	self deny: (matcher search: 'What do you know about THE QUICK BROWN FOX?')! !
-
-!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:38'!
-testCopyReplacingMatches
-	"See that the match context is preserved while copying stuff between matches:"
-	
-	| matcher |
-	matcher := self matcherClass forString: '\<\d\D+'.
-	self assert: (matcher copy: '9aaa1bbb 8ccc' replacingMatchesWith: 'foo')
-		= 'foo1bbb foo'! !
-
-!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'hfm 4/2/2010 13:52'!
-testCopyTranslatingMatches
-	| matcher |
-	matcher := self matcherClass forString: '\w+'.
-	self assert: (matcher copy: 'now is  the   time    ' translatingMatchesUsing: [ :each | each reversed ])
-		= 'won si  eht   emit    '! !
-
-!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/20/2012 20:02'!
-testEmptyStringAtBeginningOfLine
-	| matcher |
-	matcher := self matcherClass forString: '^'.
-	self
-		assert: (matcher copy: 'foo1 bar1' , String crString , 'foo2 bar2' replacingMatchesWith: '*')
-			= ('*foo1 bar1' , String crString , '*foo2 bar2')
-		description: 'An empty string at the beginning of a line'! !
-
-!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/22/2012 12:34'!
-testEmptyStringAtBeginningOfWord
-	| matcher |
-	matcher := self matcherClass forString: '\<'.
-	self
-		assert: (matcher copy: 'foo bar' replacingMatchesWith: '*')
-			= '*foo *bar'
-		description: 'An empty string at the beginning of a word'! !
-
-!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/20/2012 20:02'!
-testEmptyStringAtEndOfLine
-	| matcher |
-	matcher := self matcherClass forString: '$'.
-	self
-		assert: (matcher copy: 'foo1 bar1' , String crString , 'foo2 bar2' replacingMatchesWith: '*')
-			= ('foo1 bar1*', String crString , 'foo2 bar2*')
-		description: 'An empty string at the end of a line'! !
-
-!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/22/2012 12:34'!
-testEmptyStringAtEndOfWord
-	| matcher |
-	matcher := self matcherClass forString: '\>'.
-	self
-		assert: (matcher copy: 'foo bar' replacingMatchesWith: '*')
-			= 'foo* bar*'
-		description: 'An empty string at the end of a word'! !
-
-!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/22/2012 12:34'!
-testEmptyStringAtWordBoundary
-	| matcher |
-	matcher := self matcherClass forString: '\b'.
-	self
-		assert: (matcher copy: 'foo bar' replacingMatchesWith: '*')
-			= '*foo* *bar*'
-		description: 'An empty string at a word boundary'! !
-
-!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/22/2012 12:35'!
-testEmptyStringNotAtWordBoundary
-	| matcher |
-	matcher := self matcherClass forString: '\B'.
-	self
-		assert: (matcher copy: 'foo bar' replacingMatchesWith: '*')
-			= 'f*o*o b*a*r'
-		description: 'An empty string not at a word boundary'! !
+!RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
+henryReadme
+	self error: 'The tests in this category are based on the ones in Henry Spencer''s regexp.c package.'! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
 testHenry001
@@ -920,6 +831,44 @@ testHenry136
 testHenry137
 	self runRegex: #('\((.*), (.*)\)' '(a, b)' true (2 'a' 3 'b'))! !
 
+!RxMatcherTest methodsFor: 'accessing' stamp: 'gsa 12/22/2012 12:25'!
+matcherClass
+	^ RxMatcher! !
+
+!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:28'!
+testCaseInsensitive
+	| matcher |
+	matcher := self matcherClass forString: 'the quick brown fox' ignoreCase: true.
+	self assert: (matcher search: 'the quick brown fox').
+	self assert: (matcher search: 'The quick brown FOX').
+	self assert: (matcher search: 'What do you know about the quick brown fox?').
+	self assert: (matcher search: 'What do you know about THE QUICK BROWN FOX?')! !
+
+!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:28'!
+testCaseSensitive
+	| matcher |
+	matcher := self matcherClass forString: 'the quick brown fox' ignoreCase: false.
+	self assert: (matcher search: 'the quick brown fox').
+	self deny: (matcher search: 'The quick brown FOX').
+	self assert: (matcher search: 'What do you know about the quick brown fox?').
+	self deny: (matcher search: 'What do you know about THE QUICK BROWN FOX?')! !
+
+!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:38'!
+testCopyReplacingMatches
+	"See that the match context is preserved while copying stuff between matches:"
+	
+	| matcher |
+	matcher := self matcherClass forString: '\<\d\D+'.
+	self assert: (matcher copy: '9aaa1bbb 8ccc' replacingMatchesWith: 'foo')
+		= 'foo1bbb foo'! !
+
+!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'hfm 4/2/2010 13:52'!
+testCopyTranslatingMatches
+	| matcher |
+	matcher := self matcherClass forString: '\w+'.
+	self assert: (matcher copy: 'now is  the   time    ' translatingMatchesUsing: [ :each | each reversed ])
+		= 'won si  eht   emit    '! !
+
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:45'!
 testMatches
 	| matcher |
@@ -996,6 +945,78 @@ testMatchingRangesIn
 		self assert: range last = expected removeFirst ].
 	self assert: expected isEmpty! !
 
+!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'KenD 11/25/2016 13:39:02'!
+testRemoveHTMLTags
+	"Remove HTML Tags"
+	
+	| regex html |
+	regex := '</?[0-9A-Za-z]+[^>]*>' asRegex.
+	html := '<a>foo<b>bar</b></a>'.
+	self assert: (regex copy: html replacingMatchesWith: '') = 'foobar'
+! !
+
+!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:55'!
+testSubexpressionCount
+	| matcher |
+	#(('a' 1) ('a(b)' 2) ('a(b(c))' 3) ('(a)(b)' 3) ('(a(b))*' 3)) do: [ :pair |
+		matcher := self matcherClass forString: pair first.
+		matcher supportsSubexpressions 
+			ifTrue: [ self assert: matcher subexpressionCount = pair last ] ]! !
+
+!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/20/2012 20:02'!
+testEmptyStringAtBeginningOfLine
+	| matcher |
+	matcher := self matcherClass forString: '^'.
+	self
+		assert: (matcher copy: 'foo1 bar1' , String crString , 'foo2 bar2' replacingMatchesWith: '*')
+			= ('*foo1 bar1' , String crString , '*foo2 bar2')
+		description: 'An empty string at the beginning of a line'! !
+
+!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/22/2012 12:34'!
+testEmptyStringAtBeginningOfWord
+	| matcher |
+	matcher := self matcherClass forString: '\<'.
+	self
+		assert: (matcher copy: 'foo bar' replacingMatchesWith: '*')
+			= '*foo *bar'
+		description: 'An empty string at the beginning of a word'! !
+
+!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/20/2012 20:02'!
+testEmptyStringAtEndOfLine
+	| matcher |
+	matcher := self matcherClass forString: '$'.
+	self
+		assert: (matcher copy: 'foo1 bar1' , String crString , 'foo2 bar2' replacingMatchesWith: '*')
+			= ('foo1 bar1*', String crString , 'foo2 bar2*')
+		description: 'An empty string at the end of a line'! !
+
+!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/22/2012 12:34'!
+testEmptyStringAtEndOfWord
+	| matcher |
+	matcher := self matcherClass forString: '\>'.
+	self
+		assert: (matcher copy: 'foo bar' replacingMatchesWith: '*')
+			= 'foo* bar*'
+		description: 'An empty string at the end of a word'! !
+
+!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/22/2012 12:34'!
+testEmptyStringAtWordBoundary
+	| matcher |
+	matcher := self matcherClass forString: '\b'.
+	self
+		assert: (matcher copy: 'foo bar' replacingMatchesWith: '*')
+			= '*foo* *bar*'
+		description: 'An empty string at a word boundary'! !
+
+!RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/22/2012 12:35'!
+testEmptyStringNotAtWordBoundary
+	| matcher |
+	matcher := self matcherClass forString: '\B'.
+	self
+		assert: (matcher copy: 'foo bar' replacingMatchesWith: '*')
+			= 'f*o*o b*a*r'
+		description: 'An empty string not at a word boundary'! !
+
 !RxMatcherTest methodsFor: 'testing' stamp: 'lr 1/15/2010 19:47'!
 testRegex001
 	self runRegex: #('^.*$' 
@@ -1021,16 +1042,6 @@ testRegex004
 	self runRegex: #(':isVowel:'
 		'aei' true nil
 		'xyz' false nil)! !
-
-!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'KenD 11/25/2016 13:39:02'!
-testRemoveHTMLTags
-	"Remove HTML Tags"
-	
-	| regex html |
-	regex := '</?[0-9A-Za-z]+[^>]*>' asRegex.
-	html := '<a>foo<b>bar</b></a>'.
-	self assert: (regex copy: html replacingMatchesWith: '') = 'foobar'
-! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'gsa 12/22/2012 12:26'!
 testStringAllRangesOfRegexMatches
@@ -1104,14 +1115,6 @@ testStringRegexMatchesDo
 	'aabbcc' regex: 'b+' matchesDo: [ :each | result add: each ].
 	self assert: result size = 1.
 	self assert: result first = 'bb'! !
-
-!RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:55'!
-testSubexpressionCount
-	| matcher |
-	#(('a' 1) ('a(b)' 2) ('a(b(c))' 3) ('(a)(b)' 3) ('(a(b))*' 3)) do: [ :pair |
-		matcher := self matcherClass forString: pair first.
-		matcher supportsSubexpressions 
-			ifTrue: [ self assert: matcher subexpressionCount = pair last ] ]! !
 
 !RxMatcherTest class methodsFor: 'accessing' stamp: 'lr 1/15/2010 19:48'!
 packageNamesUnderTest

--- a/Regex-Tests.pck.st
+++ b/Regex-Tests.pck.st
@@ -1,24 +1,24 @@
 'From Cuis 5.0 of 7 November 2016 [latest update: #2974] on 22 November 2016 at 1:04:01 pm'!
 'Description Please enter a description for this package '!
-!provides: 'Regex-Tests' 1 1!
-!requires: 'Regex-Core' 1 1 nil!
-!classDefinition: #RxMatcherTest category: #'Regex-Tests-Core'!
+!provides: 'RegEx-Tests' 1 1!
+!requires: 'RegEx-Core' 1 1 nil!
+!classDefinition: #RxMatcherTest category: #'RegEx-Tests-Core'!
 TestCase subclass: #RxMatcherTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
-	category: 'Regex-Tests-Core'!
-!classDefinition: 'RxMatcherTest class' category: #'Regex-Tests-Core'!
+	category: 'RegEx-Tests-Core'!
+!classDefinition: 'RxMatcherTest class' category: #'RegEx-Tests-Core'!
 RxMatcherTest class
 	instanceVariableNames: ''!
 
-!classDefinition: #RxParserTest category: #'Regex-Tests-Core'!
+!classDefinition: #RxParserTest category: #'RegEx-Tests-Core'!
 TestCase subclass: #RxParserTest
 	instanceVariableNames: ''
 	classVariableNames: ''
 	poolDictionaries: ''
-	category: 'Regex-Tests-Core'!
-!classDefinition: 'RxParserTest class' category: #'Regex-Tests-Core'!
+	category: 'RegEx-Tests-Core'!
+!classDefinition: 'RxParserTest class' category: #'RegEx-Tests-Core'!
 RxParserTest class
 	instanceVariableNames: ''!
 

--- a/Regex-Tests.pck.st
+++ b/Regex-Tests.pck.st
@@ -1,5 +1,7 @@
-'From Cuis 4.1 of 12 December 2012 [latest update: #1524] on 30 December 2012 at 6:01:06 pm'!
+'From Cuis 5.0 of 7 November 2016 [latest update: #2974] on 22 November 2016 at 1:04:01 pm'!
 'Description Please enter a description for this package '!
+!provides: 'Regex-Tests' 1 1!
+!requires: 'Regex-Core' 1 1 nil!
 !classDefinition: #RxMatcherTest category: #'Regex-Tests-Core'!
 TestCase subclass: #RxMatcherTest
 	instanceVariableNames: ''
@@ -28,17 +30,24 @@ This class provides tests for the regular expression matcher.!
 This class provides tests for the regular expression parser.!
 
 !RxMatcherTest methodsFor: 'utilties' stamp: 'TestRunner 1/15/2010 19:38'!
-compileRegex: aString	"Compile the regex and answer the matcher, or answer nil if compilation fails."	| syntaxTree |	syntaxTree := self parserClass safelyParse: aString.	^ syntaxTree isNil ifFalse: [ self matcherClass for: syntaxTree ]! !
+compileRegex: aString
+	"Compile the regex and answer the matcher, or answer nil if compilation fails."
+
+	| syntaxTree |
+	syntaxTree := self parserClass safelyParse: aString.
+	^ syntaxTree isNil ifFalse: [ self matcherClass for: syntaxTree ]! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-henryReadme	self error: 'The tests in this category are based on the ones in Henry Spencer''s regexp.c package.'! !
+henryReadme
+	self error: 'The tests in this category are based on the ones in Henry Spencer''s regexp.c package.'! !
 
 !RxMatcherTest methodsFor: 'accessing' stamp: 'gsa 12/22/2012 12:25'!
 matcherClass
 	^ RxMatcher! !
 
 !RxMatcherTest methodsFor: 'accessing' stamp: 'lr 1/15/2010 19:39'!
-parserClass	^ RxParser! !
+parserClass
+	^ RxParser! !
 
 !RxMatcherTest methodsFor: 'utilties' stamp: 'gsa 12/22/2012 12:26'!
 runMatcher: aMatcher with: aString expect: aBoolean withSubexpressions: anArray
@@ -65,19 +74,60 @@ runMatcher: aMatcher with: aString expect: aBoolean withSubexpressions: anArray
 			description: 'Subexpression ' , sub printString , ': expected ' , subExpect printString , ', but got ' , subGot printString ]! !
 
 !RxMatcherTest methodsFor: 'utilties' stamp: 'lr 1/15/2010 19:31'!
-runRegex: anArray	"Run a clause anArray against a set of tests. Each clause is an array with a regex source string followed by sequence of 3-tuples. Each three-element group is one test to try against the regex, and includes: 1) test string; 2) expected result; 3) expected subexpression as an array of (index, substring), or nil."	| source matcher |	source := anArray first.	matcher := self compileRegex: source.	matcher isNil		ifTrue: [			(anArray at: 2) isNil				ifFalse: [ self signalFailure: 'Compilation failed, should have succeeded: ' , source printString ] ]		ifFalse: [			(anArray at: 2) isNil				ifTrue: [ self signalFailure: 'Compilation succeeded, should have failed: ' , source printString ]				ifFalse: [					2 to: anArray size by: 3 do: [ :index | 						self 							runMatcher: matcher							with: (anArray at: index)							expect: (anArray at: index + 1)							withSubexpressions: (anArray at: index + 2) ] ] ]! !
+runRegex: anArray
+	"Run a clause anArray against a set of tests. Each clause is an array with a regex source string followed by sequence of 3-tuples. Each three-element group is one test to try against the regex, and includes: 1) test string; 2) expected result; 3) expected subexpression as an array of (index, substring), or nil."
+
+	| source matcher |
+	source := anArray first.
+	matcher := self compileRegex: source.
+	matcher isNil
+		ifTrue: [
+			(anArray at: 2) isNil
+				ifFalse: [ self signalFailure: 'Compilation failed, should have succeeded: ' , source printString ] ]
+		ifFalse: [
+			(anArray at: 2) isNil
+				ifTrue: [ self signalFailure: 'Compilation succeeded, should have failed: ' , source printString ]
+				ifFalse: [
+					2 to: anArray size by: 3 do: [ :index | 
+						self 
+							runMatcher: matcher
+							with: (anArray at: index)
+							expect: (anArray at: index + 1)
+							withSubexpressions: (anArray at: index + 2) ] ] ]! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:28'!
-testCaseInsensitive	| matcher |	matcher := self matcherClass forString: 'the quick brown fox' ignoreCase: true.	self assert: (matcher search: 'the quick brown fox').	self assert: (matcher search: 'The quick brown FOX').	self assert: (matcher search: 'What do you know about the quick brown fox?').	self assert: (matcher search: 'What do you know about THE QUICK BROWN FOX?')! !
+testCaseInsensitive
+	| matcher |
+	matcher := self matcherClass forString: 'the quick brown fox' ignoreCase: true.
+	self assert: (matcher search: 'the quick brown fox').
+	self assert: (matcher search: 'The quick brown FOX').
+	self assert: (matcher search: 'What do you know about the quick brown fox?').
+	self assert: (matcher search: 'What do you know about THE QUICK BROWN FOX?')! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:28'!
-testCaseSensitive	| matcher |	matcher := self matcherClass forString: 'the quick brown fox' ignoreCase: false.	self assert: (matcher search: 'the quick brown fox').	self deny: (matcher search: 'The quick brown FOX').	self assert: (matcher search: 'What do you know about the quick brown fox?').	self deny: (matcher search: 'What do you know about THE QUICK BROWN FOX?')! !
+testCaseSensitive
+	| matcher |
+	matcher := self matcherClass forString: 'the quick brown fox' ignoreCase: false.
+	self assert: (matcher search: 'the quick brown fox').
+	self deny: (matcher search: 'The quick brown FOX').
+	self assert: (matcher search: 'What do you know about the quick brown fox?').
+	self deny: (matcher search: 'What do you know about THE QUICK BROWN FOX?')! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:38'!
-testCopyReplacingMatches	"See that the match context is preserved while copying stuff between matches:"		| matcher |	matcher := self matcherClass forString: '\<\d\D+'.	self assert: (matcher copy: '9aaa1bbb 8ccc' replacingMatchesWith: 'foo')		= 'foo1bbb foo'! !
+testCopyReplacingMatches
+	"See that the match context is preserved while copying stuff between matches:"
+	
+	| matcher |
+	matcher := self matcherClass forString: '\<\d\D+'.
+	self assert: (matcher copy: '9aaa1bbb 8ccc' replacingMatchesWith: 'foo')
+		= 'foo1bbb foo'! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'hfm 4/2/2010 13:52'!
-testCopyTranslatingMatches	| matcher |	matcher := self matcherClass forString: '\w+'.	self assert: (matcher copy: 'now is  the   time    ' translatingMatchesUsing: [ :each | each reversed ])		= 'won si  eht   emit    '! !
+testCopyTranslatingMatches
+	| matcher |
+	matcher := self matcherClass forString: '\w+'.
+	self assert: (matcher copy: 'now is  the   time    ' translatingMatchesUsing: [ :each | each reversed ])
+		= 'won si  eht   emit    '! !
 
 !RxMatcherTest methodsFor: 'testing-empty' stamp: 'gsa 12/20/2012 20:02'!
 testEmptyStringAtBeginningOfLine
@@ -134,454 +184,843 @@ testEmptyStringNotAtWordBoundary
 		description: 'An empty string not at a word boundary'! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry001	self runRegex: #('abc'		'abc' true (1 'abc')		'xbc' false nil		'axc' false nil		'abx' false nil		'xabcy' true (1 'abc')		'ababc' true (1 'abc'))! !
+testHenry001
+	self runRegex: #('abc'
+		'abc' true (1 'abc')
+		'xbc' false nil
+		'axc' false nil
+		'abx' false nil
+		'xabcy' true (1 'abc')
+		'ababc' true (1 'abc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry002	self runRegex: #('ab*c'		'abc' true (1 'abc'))! !
+testHenry002
+	self runRegex: #('ab*c'
+		'abc' true (1 'abc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry003	self runRegex: #('ab*bc'		'abc' true (1 'abc')		'abbc' true (1 'abbc')		'abbbbc' true (1 'abbbbc'))! !
+testHenry003
+	self runRegex: #('ab*bc'
+		'abc' true (1 'abc')
+		'abbc' true (1 'abbc')
+		'abbbbc' true (1 'abbbbc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry004	self runRegex: #('ab+bc'			'abbc' true (1 'abbc')		'abc' false nil		'abq' false nil		'abbbbc' true (1 'abbbbc'))! !
+testHenry004
+	self runRegex: #('ab+bc'	
+		'abbc' true (1 'abbc')
+		'abc' false nil
+		'abq' false nil
+		'abbbbc' true (1 'abbbbc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry005	self runRegex: #('ab?bc'		'abbc' true (1 'abbc')		'abc' true (1 'abc')		'abbbbc' false nil		'abc' true (1 'abc'))! !
+testHenry005
+	self runRegex: #('ab?bc'
+		'abbc' true (1 'abbc')
+		'abc' true (1 'abc')
+		'abbbbc' false nil
+		'abc' true (1 'abc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry006	self runRegex: #('^abc$'		'abc' true (1 'abc')		'abcc' false nil		'aabc' false nil)! !
+testHenry006
+	self runRegex: #('^abc$'
+		'abc' true (1 'abc')
+		'abcc' false nil
+		'aabc' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry007	self runRegex: #('^abc'		'abcc' true (1 'abc'))! !
+testHenry007
+	self runRegex: #('^abc'
+		'abcc' true (1 'abc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry008	self runRegex: #('abc$'		'aabc' true (1 'abc'))! !
+testHenry008
+	self runRegex: #('abc$'
+		'aabc' true (1 'abc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry009	self runRegex: #('^'		'abc' true nil)! !
+testHenry009
+	self runRegex: #('^'
+		'abc' true nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry010	self runRegex: #('$'		'abc' true nil)! !
+testHenry010
+	self runRegex: #('$'
+		'abc' true nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry011	self runRegex: #('a.c'		'abc' true (1 'abc')		'axc' true (1 'axc'))! !
+testHenry011
+	self runRegex: #('a.c'
+		'abc' true (1 'abc')
+		'axc' true (1 'axc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry012	"Need to get creative to include the null character..."	self runRegex: #('a.*c'			'axyzc' true (1 'axyzc')		'axy zc' true (1 'axy zc') "testing that a dot matches a space"		), (Array with: 'axy', (String with: 0 asCharacter), 'zc'), #(false nil "testing that a dot does not match a null"		'axyzd' false nil)! !
+testHenry012
+	"Need to get creative to include the null character..."
+	self runRegex: #('a.*c'	
+		'axyzc' true (1 'axyzc')
+		'axy zc' true (1 'axy zc') "testing that a dot matches a space"
+		), (Array with: 'axy', (String with: 0 asCharacter), 'zc'), #(false nil "testing that a dot does not match a null"
+		'axyzd' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry013	self runRegex: #('.a.*'		'1234abc' true (1 '4abc')		'abcd' false nil)! !
+testHenry013
+	self runRegex: #('.a.*'
+		'1234abc' true (1 '4abc')
+		'abcd' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry014	self runRegex: #('a\w+c'		' abbbbc ' true (1 'abbbbc')		'abb bc' false nil)! !
+testHenry014
+	self runRegex: #('a\w+c'
+		' abbbbc ' true (1 'abbbbc')
+		'abb bc' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry015	self runRegex: #('\w+'		'  	foobar	quux' true (1 'foobar')		' 	~!!@#$%^&*()-+=\|/?.>,<' false nil)! !
+testHenry015
+	self runRegex: #('\w+'
+		'  	foobar	quux' true (1 'foobar')
+		' 	~!!@#$%^&*()-+=\|/?.>,<' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry016	self runRegex: #('a\W+c'		'a   c' true (1 'a   c')		'a bc' false nil)! !
+testHenry016
+	self runRegex: #('a\W+c'
+		'a   c' true (1 'a   c')
+		'a bc' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry017	self runRegex: #('\W+'		'foo!!@#$bar' true (1 '!!@#$')		'foobar' false nil)! !
+testHenry017
+	self runRegex: #('\W+'
+		'foo!!@#$bar' true (1 '!!@#$')
+		'foobar' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry018	self runRegex: #('a\s*c'		'a   c' true (1 'a   c')		'a bc' false nil)! !
+testHenry018
+	self runRegex: #('a\s*c'
+		'a   c' true (1 'a   c')
+		'a bc' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry019	self runRegex: #('\s+'		'abc3457 sd' true (1 ' ')		'1234$^*^&asdfb' false nil)! !
+testHenry019
+	self runRegex: #('\s+'
+		'abc3457 sd' true (1 ' ')
+		'1234$^*^&asdfb' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry020	self runRegex: #('a\S*c'		'aqwertyc' true (1 'aqwertyc')		'ab c' false nil)! !
+testHenry020
+	self runRegex: #('a\S*c'
+		'aqwertyc' true (1 'aqwertyc')
+		'ab c' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry021	self runRegex: #('\S+'		'     	asdf		' true (1 'asdf')		' 				' false nil)! !
+testHenry021
+	self runRegex: #('\S+'
+		'     	asdf		' true (1 'asdf')
+		' 	
+			' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry022	self runRegex: #('a\d+c'		'a0123456789c' true (1 'a0123456789c')		'a12b34c' false nil)! !
+testHenry022
+	self runRegex: #('a\d+c'
+		'a0123456789c' true (1 'a0123456789c')
+		'a12b34c' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry023	self runRegex: #('\d+'		'foo@#$%123ASD #$$%^&' true (1 '123')		'foo!!@#$asdfl;' false nil)! !
+testHenry023
+	self runRegex: #('\d+'
+		'foo@#$%123ASD #$$%^&' true (1 '123')
+		'foo!!@#$asdfl;' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry024	self runRegex: #('a\D+c'		'aqwertyc' true (1 'aqwertyc')		'aqw6ertc' false nil)! !
+testHenry024
+	self runRegex: #('a\D+c'
+		'aqwertyc' true (1 'aqwertyc')
+		'aqw6ertc' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry025	self runRegex: #('\D+'		'1234 abc 456' true (1 ' abc ')		'1234567890' false nil)! !
+testHenry025
+	self runRegex: #('\D+'
+		'1234 abc 456' true (1 ' abc ')
+		'1234567890' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry026	self runRegex: #('(f|o)+\b'		'foo' true (1 'foo')		' foo ' true (1 'foo'))! !
+testHenry026
+	self runRegex: #('(f|o)+\b'
+		'foo' true (1 'foo')
+		' foo ' true (1 'foo'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry027	self runRegex: #('\ba\w+' "a word beginning with an A"		'land ancient' true (1 'ancient')		'antique vase' true (1 'antique')		'goofy foobar' false nil)! !
+testHenry027
+	self runRegex: #('\ba\w+' "a word beginning with an A"
+		'land ancient' true (1 'ancient')
+		'antique vase' true (1 'antique')
+		'goofy foobar' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry028	self runRegex: #('(f|o)+\B'		'quuxfoobar' true (1 'foo')		'quuxfoo ' true (1 'fo'))! !
+testHenry028
+	self runRegex: #('(f|o)+\B'
+		'quuxfoobar' true (1 'foo')
+		'quuxfoo ' true (1 'fo'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry029	self runRegex: #('\Ba\w+' "a word with an A in the middle, match at A and further"		'land ancient' true (1 'and')		'antique vase' true (1 'ase')		'smalltalk shall overcome' true (1 'alltalk')		'foonix is better' false nil)! !
+testHenry029
+	self runRegex: #('\Ba\w+' "a word with an A in the middle, match at A and further"
+		'land ancient' true (1 'and')
+		'antique vase' true (1 'ase')
+		'smalltalk shall overcome' true (1 'alltalk')
+		'foonix is better' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry030	self runRegex: #('fooa\>.*'		'fooa ' true nil		'fooa123' false nil		'fooa bar' true nil		'fooa' true nil		'fooargh' false nil)! !
+testHenry030
+	self runRegex: #('fooa\>.*'
+		'fooa ' true nil
+		'fooa123' false nil
+		'fooa bar' true nil
+		'fooa' true nil
+		'fooargh' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry031	self runRegex: #('\>.+abc'		' abcde fg' false nil		'foo abcde' true (1 ' abc')		'abcde' false nil)! !
+testHenry031
+	self runRegex: #('\>.+abc'
+		' abcde fg' false nil
+		'foo abcde' true (1 ' abc')
+		'abcde' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry032	self runRegex: #('\<foo.*'		'foo' true nil		'foobar' true nil		'qfoobarq foonix' true (1 'foonix')		' foo' true nil		' 12foo' false nil		'barfoo' false nil)! !
+testHenry032
+	self runRegex: #('\<foo.*'
+		'foo' true nil
+		'foobar' true nil
+		'qfoobarq foonix' true (1 'foonix')
+		' foo' true nil
+		' 12foo' false nil
+		'barfoo' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry033	self runRegex: #('.+\<foo'		'foo' false nil		'ab foo' true (1 'ab foo')		'abfoo' false nil)! !
+testHenry033
+	self runRegex: #('.+\<foo'
+		'foo' false nil
+		'ab foo' true (1 'ab foo')
+		'abfoo' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry034	self runRegex: #('a[bc]d'		'abc' false nil		'abd' true (1 'abd'))! !
+testHenry034
+	self runRegex: #('a[bc]d'
+		'abc' false nil
+		'abd' true (1 'abd'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry035	self runRegex: #('a[b-d]e'		'abd' false nil		'ace' true (1 'ace'))! !
+testHenry035
+	self runRegex: #('a[b-d]e'
+		'abd' false nil
+		'ace' true (1 'ace'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry036	self runRegex: #('a[b-d]'		'aac' true (1 'ac'))! !
+testHenry036
+	self runRegex: #('a[b-d]'
+		'aac' true (1 'ac'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry037	self runRegex: #('a[-b]'		'a-' true (1 'a-'))! !
+testHenry037
+	self runRegex: #('a[-b]'
+		'a-' true (1 'a-'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry038	self runRegex: #('a[b-]'		'a-' true (1 'a-'))! !
+testHenry038
+	self runRegex: #('a[b-]'
+		'a-' true (1 'a-'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry039	self runRegex: #('a[a-b-c]' nil)! !
+testHenry039
+	self runRegex: #('a[a-b-c]' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry040	self runRegex: #('[k]'		'ab' false nil)! !
+testHenry040
+	self runRegex: #('[k]'
+		'ab' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry041	self runRegex: #('a[b-a]' nil)! !
+testHenry041
+	self runRegex: #('a[b-a]' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry042	self runRegex: #('a[]b' nil)! !
+testHenry042
+	self runRegex: #('a[]b' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry043	self runRegex: #('a[' nil)! !
+testHenry043
+	self runRegex: #('a[' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry044	self runRegex: #('a]' 		'a]' true (1 'a]'))! !
+testHenry044
+	self runRegex: #('a]' 
+		'a]' true (1 'a]'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry045	self runRegex: #('a[]]b'		'a]b' true (1 'a]b'))! !
+testHenry045
+	self runRegex: #('a[]]b'
+		'a]b' true (1 'a]b'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry046	self runRegex: #('a[^bc]d'		'aed' true (1 'aed')		'abd' false nil)! !
+testHenry046
+	self runRegex: #('a[^bc]d'
+		'aed' true (1 'aed')
+		'abd' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry047	self runRegex: #('a[^-b]c'		'adc' true (1 'adc')		'a-c' false nil)! !
+testHenry047
+	self runRegex: #('a[^-b]c'
+		'adc' true (1 'adc')
+		'a-c' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry048	self runRegex: #('a[^]b]c'		'a]c' false nil		'adc' true (1 'adc'))! !
+testHenry048
+	self runRegex: #('a[^]b]c'
+		'a]c' false nil
+		'adc' true (1 'adc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry049	self runRegex: #('[\de]+'		'01234' true (1 '01234')		'0123e456' true (1 '0123e456')		'0123e45g78' true (1 '0123e45'))! !
+testHenry049
+	self runRegex: #('[\de]+'
+		'01234' true (1 '01234')
+		'0123e456' true (1 '0123e456')
+		'0123e45g78' true (1 '0123e45'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry050	self runRegex: #('[e\d]+' "reversal of the above, should be the same"		'01234' true (1 '01234')		'0123e456' true (1 '0123e456')		'0123e45g78' true (1 '0123e45'))! !
+testHenry050
+	self runRegex: #('[e\d]+' "reversal of the above, should be the same"
+		'01234' true (1 '01234')
+		'0123e456' true (1 '0123e456')
+		'0123e45g78' true (1 '0123e45'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry051	self runRegex: #('[\D]+'		'123abc45def78' true (1 'abc'))! !
+testHenry051
+	self runRegex: #('[\D]+'
+		'123abc45def78' true (1 'abc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry052	self runRegex: #('[[:digit:]e]+'		'01234' true (1 '01234')		'0123e456' true (1 '0123e456')		'0123e45g78' true (1 '0123e45'))! !
+testHenry052
+	self runRegex: #('[[:digit:]e]+'
+		'01234' true (1 '01234')
+		'0123e456' true (1 '0123e456')
+		'0123e45g78' true (1 '0123e45'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry053	self runRegex: #('[\s]+'		'2  spaces' true (1 '  '))! !
+testHenry053
+	self runRegex: #('[\s]+'
+		'2  spaces' true (1 '  '))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry054	self runRegex: #('[\S]+'		'  word12!!@#$  ' true (1 'word12!!@#$'))! !
+testHenry054
+	self runRegex: #('[\S]+'
+		'  word12!!@#$  ' true (1 'word12!!@#$'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry055	self runRegex: #('[\w]+'		' 	foo123bar	45' true (1 'foo123bar'))! !
+testHenry055
+	self runRegex: #('[\w]+'
+		' 	foo123bar	45' true (1 'foo123bar'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry056	self runRegex: #('[\W]+'		'fii234!!@#$34f' true (1 '!!@#$'))! !
+testHenry056
+	self runRegex: #('[\W]+'
+		'fii234!!@#$34f' true (1 '!!@#$'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry057	self runRegex: #('[^[:alnum:]]+'		'fii234!!@#$34f' true (1 '!!@#$'))! !
+testHenry057
+	self runRegex: #('[^[:alnum:]]+'
+		'fii234!!@#$34f' true (1 '!!@#$'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry058	self runRegex: #('[%&[:alnum:]]+'		'foo%3' true (1 'foo%3')		'foo34&rt4$57a' true (1 'foo34&rt4')		'!!@#$' false nil)! !
+testHenry058
+	self runRegex: #('[%&[:alnum:]]+'
+		'foo%3' true (1 'foo%3')
+		'foo34&rt4$57a' true (1 'foo34&rt4')
+		'!!@#$' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry059	self runRegex: #('[[:alpha:]]+'		' 123foo3 ' true (1 'foo')		'123foo' true (1 'foo')		'foo1b' true (1 'foo'))! !
+testHenry059
+	self runRegex: #('[[:alpha:]]+'
+		' 123foo3 ' true (1 'foo')
+		'123foo' true (1 'foo')
+		'foo1b' true (1 'foo'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry060	self runRegex: #('[[:cntrl:]]+'		' a 1234asdf' false nil)! !
+testHenry060
+	self runRegex: #('[[:cntrl:]]+'
+		' a 1234asdf' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry061	self runRegex: #('[[:lower:]]+'		'UPPERlower1234' true (1 'lower')		'lowerUPPER' true (1 'lower'))! !
+testHenry061
+	self runRegex: #('[[:lower:]]+'
+		'UPPERlower1234' true (1 'lower')
+		'lowerUPPER' true (1 'lower'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry062	self runRegex: #('[[:upper:]]+'		'UPPERlower1234' true (1 'UPPER')		'lowerUPPER ' true (1 'UPPER'))! !
+testHenry062
+	self runRegex: #('[[:upper:]]+'
+		'UPPERlower1234' true (1 'UPPER')
+		'lowerUPPER ' true (1 'UPPER'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry063	self runRegex: #('[[:space:]]+'		'2  spaces' true (1 '  '))! !
+testHenry063
+	self runRegex: #('[[:space:]]+'
+		'2  spaces' true (1 '  '))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry064	self runRegex: #('[^[:space:]]+'		'  word12!!@#$  ' true (1 'word12!!@#$'))! !
+testHenry064
+	self runRegex: #('[^[:space:]]+'
+		'  word12!!@#$  ' true (1 'word12!!@#$'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry065	self runRegex: #('[[:graph:]]+'		'abc' true (1 'abc'))! !
+testHenry065
+	self runRegex: #('[[:graph:]]+'
+		'abc' true (1 'abc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry066	self runRegex: #('[[:print:]]+'		'abc' true (1 'abc'))! !
+testHenry066
+	self runRegex: #('[[:print:]]+'
+		'abc' true (1 'abc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry067	self runRegex: #('[^[:punct:]]+'		'!!hello,world!!' true (1 'hello'))! !
+testHenry067
+	self runRegex: #('[^[:punct:]]+'
+		'!!hello,world!!' true (1 'hello'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry068	self runRegex: #('[[:xdigit:]]+'		'  x10FCD  ' true (1 '10FCD')		' hgfedcba0123456789ABCDEFGH '			true (1 'fedcba0123456789ABCDEF'))! !
+testHenry068
+	self runRegex: #('[[:xdigit:]]+'
+		'  x10FCD  ' true (1 '10FCD')
+		' hgfedcba0123456789ABCDEFGH '
+			true (1 'fedcba0123456789ABCDEF'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry069	self runRegex: #('ab|cd'		'abc' true (1 'ab')		'abcd' true (1 'ab'))! !
+testHenry069
+	self runRegex: #('ab|cd'
+		'abc' true (1 'ab')
+		'abcd' true (1 'ab'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry070	self runRegex: #('()ef'		'def' true (1 'ef' 2 ''))! !
+testHenry070
+	self runRegex: #('()ef'
+		'def' true (1 'ef' 2 ''))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry071	self runRegex: #('()*' nil)! !
+testHenry071
+	self runRegex: #('()*' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry072	self runRegex: #('*a' nil)! !
+testHenry072
+	self runRegex: #('*a' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry073	self runRegex: #('^*' nil)! !
+testHenry073
+	self runRegex: #('^*' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry074	self runRegex: #('$*' nil)! !
+testHenry074
+	self runRegex: #('$*' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry075	self runRegex: #('(*)b' nil)! !
+testHenry075
+	self runRegex: #('(*)b' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry076	self runRegex: #('$b'	'b' false nil)! !
+testHenry076
+	self runRegex: #('$b'	'b' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry077	self runRegex: #('a\' nil)! !
+testHenry077
+	self runRegex: #('a\' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry078	self runRegex: #('a\(b'		'a(b' true (1 'a(b'))! !
+testHenry078
+	self runRegex: #('a\(b'
+		'a(b' true (1 'a(b'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry079	self runRegex: #('a\(*b'		'ab' true (1 'ab')		'a((b' true (1 'a((b'))! !
+testHenry079
+	self runRegex: #('a\(*b'
+		'ab' true (1 'ab')
+		'a((b' true (1 'a((b'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry080	self runRegex: #('a\\b'		'a\b' true (1 'a\b'))! !
+testHenry080
+	self runRegex: #('a\\b'
+		'a\b' true (1 'a\b'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry081	self runRegex: #('abc)' nil)! !
+testHenry081
+	self runRegex: #('abc)' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry082	self runRegex: #('(abc' nil)! !
+testHenry082
+	self runRegex: #('(abc' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry083	self runRegex: #('((a))'		'abc' true (1 'a' 2 'a' 3 'a'))! !
+testHenry083
+	self runRegex: #('((a))'
+		'abc' true (1 'a' 2 'a' 3 'a'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry084	self runRegex: #('(a)b(c)'		'abc' true (1 'abc' 2 'a' 3 'c'))! !
+testHenry084
+	self runRegex: #('(a)b(c)'
+		'abc' true (1 'abc' 2 'a' 3 'c'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry085	self runRegex: #('a+b+c'		'aabbabc' true (1 'abc'))! !
+testHenry085
+	self runRegex: #('a+b+c'
+		'aabbabc' true (1 'abc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry086	self runRegex: #('a**' nil)! !
+testHenry086
+	self runRegex: #('a**' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry087	self runRegex: #('a*?' nil)! !
+testHenry087
+	self runRegex: #('a*?' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry088	self runRegex: #('(a*)*' nil)! !
+testHenry088
+	self runRegex: #('(a*)*' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry089	self runRegex: #('(a*)+' nil)! !
+testHenry089
+	self runRegex: #('(a*)+' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry090	self runRegex: #('(a|)*' nil)! !
+testHenry090
+	self runRegex: #('(a|)*' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry091	self runRegex: #('(a*|b)*' nil)! !
+testHenry091
+	self runRegex: #('(a*|b)*' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry092	self runRegex: #('(a+|b)*'		'ab' true (1 'ab' 2 'b'))! !
+testHenry092
+	self runRegex: #('(a+|b)*'
+		'ab' true (1 'ab' 2 'b'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry093	self runRegex: #('(a+|b)+'		'ab' true (1 'ab' 2 'b'))! !
+testHenry093
+	self runRegex: #('(a+|b)+'
+		'ab' true (1 'ab' 2 'b'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry094	self runRegex: #('(a+|b)?'		'ab' true (1 'a' 2 'a'))! !
+testHenry094
+	self runRegex: #('(a+|b)?'
+		'ab' true (1 'a' 2 'a'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry095	self runRegex: #('[^ab]*'		'cde' true (1 'cde'))! !
+testHenry095
+	self runRegex: #('[^ab]*'
+		'cde' true (1 'cde'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry096	self runRegex: #('(^)*' nil)! !
+testHenry096
+	self runRegex: #('(^)*' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry097	self runRegex: #('(ab|)*' nil)! !
+testHenry097
+	self runRegex: #('(ab|)*' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry098	self runRegex: #(')(' nil)! !
+testHenry098
+	self runRegex: #(')(' nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry099	self runRegex: #('' 'abc' true (1 ''))! !
+testHenry099
+	self runRegex: #('' 'abc' true (1 ''))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry100	self runRegex: #('abc' '' false nil)! !
+testHenry100
+	self runRegex: #('abc' '' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry101	self runRegex: #('a*'		'' true '')! !
+testHenry101
+	self runRegex: #('a*'
+		'' true '')! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry102	self runRegex: #('abcd'		'abcd' true (1 'abcd'))! !
+testHenry102
+	self runRegex: #('abcd'
+		'abcd' true (1 'abcd'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry103	self runRegex: #('a(bc)d'		'abcd' true (1 'abcd' 2 'bc'))! !
+testHenry103
+	self runRegex: #('a(bc)d'
+		'abcd' true (1 'abcd' 2 'bc'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry104	self runRegex: #('([abc])*d'		'abbbcd' true (1 'abbbcd' 2 'c'))! !
+testHenry104
+	self runRegex: #('([abc])*d'
+		'abbbcd' true (1 'abbbcd' 2 'c'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry105	self runRegex: #('([abc])*bcd'		'abcd' true (1 'abcd' 2 'a'))! !
+testHenry105
+	self runRegex: #('([abc])*bcd'
+		'abcd' true (1 'abcd' 2 'a'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry106	self runRegex: #('a|b|c|d|e' 'e' true (1 'e'))! !
+testHenry106
+	self runRegex: #('a|b|c|d|e' 'e' true (1 'e'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry107	self runRegex: #('(a|b|c|d|e)f'		'ef' true (1 'ef' 2 'e'))	"	((a*|b))*	-	c	-	-"! !
+testHenry107
+	self runRegex: #('(a|b|c|d|e)f'
+		'ef' true (1 'ef' 2 'e'))
+	"	((a*|b))*	-	c	-	-"! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry108	self runRegex: #('abcd*efg' 		'abcdefg' true (1 'abcdefg'))! !
+testHenry108
+	self runRegex: #('abcd*efg' 
+		'abcdefg' true (1 'abcdefg'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry109	self runRegex: #('ab*' 		'xabyabbbz' true (1 'ab')		'xayabbbz' true (1 'a'))! !
+testHenry109
+	self runRegex: #('ab*' 
+		'xabyabbbz' true (1 'ab')
+		'xayabbbz' true (1 'a'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry110	self runRegex: #('(ab|cd)e' 'abcde' true (1 'cde' 2 'cd'))! !
+testHenry110
+	self runRegex: #('(ab|cd)e' 'abcde' true (1 'cde' 2 'cd'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry111	self runRegex: #('[abhgefdc]ij' 'hij' true (1 'hij'))! !
+testHenry111
+	self runRegex: #('[abhgefdc]ij' 'hij' true (1 'hij'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry112	self runRegex: #('^(ab|cd)e' 'abcde' false nil)	! !
+testHenry112
+	self runRegex: #('^(ab|cd)e' 'abcde' false nil)
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry113	self runRegex: #('(abc|)def' 'abcdef' true nil)	! !
+testHenry113
+	self runRegex: #('(abc|)def' 'abcdef' true nil)
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry114	self runRegex: #('(a|b)c*d' 'abcd' true (1 'bcd' 2 'b'))	! !
+testHenry114
+	self runRegex: #('(a|b)c*d' 'abcd' true (1 'bcd' 2 'b'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry115	self runRegex: #('(ab|ab*)bc' 'abc' true (1 'abc' 2 'a'))	! !
+testHenry115
+	self runRegex: #('(ab|ab*)bc' 'abc' true (1 'abc' 2 'a'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry116	self runRegex: #('a([bc]*)c*' 'abc' true (1 'abc' 2 'bc'))	! !
+testHenry116
+	self runRegex: #('a([bc]*)c*' 'abc' true (1 'abc' 2 'bc'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry117	self runRegex: #('a([bc]*)(c*d)' 'abcd' true (1 'abcd' 2 'bc' 3 'd'))	! !
+testHenry117
+	self runRegex: #('a([bc]*)(c*d)' 'abcd' true (1 'abcd' 2 'bc' 3 'd'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry118	self runRegex: #('a([bc]+)(c*d)' 'abcd' true (1 'abcd' 2 'bc' 3 'd'))	! !
+testHenry118
+	self runRegex: #('a([bc]+)(c*d)' 'abcd' true (1 'abcd' 2 'bc' 3 'd'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry119	self runRegex: #('a([bc]*)(c+d)' 'abcd' true (1 'abcd' 2 'b' 3 'cd'))	! !
+testHenry119
+	self runRegex: #('a([bc]*)(c+d)' 'abcd' true (1 'abcd' 2 'b' 3 'cd'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry120	self runRegex: #('a[bcd]*dcdcde' 'adcdcde' true (1 'adcdcde'))	! !
+testHenry120
+	self runRegex: #('a[bcd]*dcdcde' 'adcdcde' true (1 'adcdcde'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry121	self runRegex: #('a[bcd]+dcdcde' 'adcdcde' false nil)	! !
+testHenry121
+	self runRegex: #('a[bcd]+dcdcde' 'adcdcde' false nil)
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry122	self runRegex: #('(ab|a)b*c' 'abc' true (1 'abc'))	! !
+testHenry122
+	self runRegex: #('(ab|a)b*c' 'abc' true (1 'abc'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry123	self runRegex: #('((a)(b)c)(d)' 'abcd' true (1 'abcd' 3 'a' 4 'b' 5 'd'))	! !
+testHenry123
+	self runRegex: #('((a)(b)c)(d)' 'abcd' true (1 'abcd' 3 'a' 4 'b' 5 'd'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry124	self runRegex: #('[ -~]*' 'abc' true (1 'abc'))	! !
+testHenry124
+	self runRegex: #('[ -~]*' 'abc' true (1 'abc'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry125	self runRegex: #('[ -~ -~]*' 'abc' true (1 'abc'))	! !
+testHenry125
+	self runRegex: #('[ -~ -~]*' 'abc' true (1 'abc'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry126	self runRegex: #('[ -~ -~ -~]*' 'abc' true (1 'abc'))	! !
+testHenry126
+	self runRegex: #('[ -~ -~ -~]*' 'abc' true (1 'abc'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry127	self runRegex: #('[ -~ -~ -~ -~]*' 'abc' true (1 'abc'))	! !
+testHenry127
+	self runRegex: #('[ -~ -~ -~ -~]*' 'abc' true (1 'abc'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry128	self runRegex: #('[ -~ -~ -~ -~ -~]*' 'abc' true (1 'abc'))	! !
+testHenry128
+	self runRegex: #('[ -~ -~ -~ -~ -~]*' 'abc' true (1 'abc'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry129	self runRegex: #('[ -~ -~ -~ -~ -~ -~]*' 'abc' true (1 'abc'))	! !
+testHenry129
+	self runRegex: #('[ -~ -~ -~ -~ -~ -~]*' 'abc' true (1 'abc'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry130	self runRegex: #('[ -~ -~ -~ -~ -~ -~ -~]*' 'abc' true (1 'abc'))	! !
+testHenry130
+	self runRegex: #('[ -~ -~ -~ -~ -~ -~ -~]*' 'abc' true (1 'abc'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry131	self runRegex: #('[a-zA-Z_][a-zA-Z0-9_]*' 'alpha' true (1 'alpha'))	! !
+testHenry131
+	self runRegex: #('[a-zA-Z_][a-zA-Z0-9_]*' 'alpha' true (1 'alpha'))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry132	self runRegex: #('^a(bc+|b[eh])g|.h$' 'abh' true (1 'bh' 2 nil))	! !
+testHenry132
+	self runRegex: #('^a(bc+|b[eh])g|.h$' 'abh' true (1 'bh' 2 nil))
+	! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry133	self runRegex: #('(bc+d$|ef*g.|h?i(j|k))' 		'effgz' true (1 'effgz' 2 'effgz' 3 nil)		'ij' true (1 'ij' 2 'ij' 3 'j')		'effg' false nil		'bcdd' false nil		'reffgz' true (1 'effgz' 2 'effgz' 3 nil))! !
+testHenry133
+	self runRegex: #('(bc+d$|ef*g.|h?i(j|k))' 
+		'effgz' true (1 'effgz' 2 'effgz' 3 nil)
+		'ij' true (1 'ij' 2 'ij' 3 'j')
+		'effg' false nil
+		'bcdd' false nil
+		'reffgz' true (1 'effgz' 2 'effgz' 3 nil))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry134	self runRegex: #('(((((((((a)))))))))' 'a' true (1 'a'))! !
+testHenry134
+	self runRegex: #('(((((((((a)))))))))' 'a' true (1 'a'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry135	self runRegex: #('multiple words of text' 		'uh-uh' false nil		'multiple words of text, yeah' true (1 'multiple words of text'))! !
+testHenry135
+	self runRegex: #('multiple words of text' 
+		'uh-uh' false nil
+		'multiple words of text, yeah' true (1 'multiple words of text'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry136	self runRegex: #('(.*)c(.*)' 'abcde' true (1 'abcde' 2 'ab' 3 'de'))! !
+testHenry136
+	self runRegex: #('(.*)c(.*)' 'abcde' true (1 'abcde' 2 'ab' 3 'de'))! !
 
 !RxMatcherTest methodsFor: 'testing-henry' stamp: 'lr 1/15/2010 19:46'!
-testHenry137	self runRegex: #('\((.*), (.*)\)' '(a, b)' true (2 'a' 3 'b'))! !
+testHenry137
+	self runRegex: #('\((.*), (.*)\)' '(a, b)' true (2 'a' 3 'b'))! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:45'!
-testMatches	| matcher |	matcher := self matcherClass forString: '\w+'.	self assert: (matcher matches: 'now').	self deny: (matcher matches: 'now is')! !
+testMatches
+	| matcher |
+	matcher := self matcherClass forString: '\w+'.
+	self assert: (matcher matches: 'now').
+	self deny: (matcher matches: 'now is')! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:38'!
-testMatchesIn	| matcher |	matcher := self matcherClass forString: '\w+'.	self assert: (matcher matchesIn: 'now is the time') asArray 		= #('now' 'is' 'the' 'time')! !
+testMatchesIn
+	| matcher |
+	matcher := self matcherClass forString: '\w+'.
+	self assert: (matcher matchesIn: 'now is the time') asArray 
+		= #('now' 'is' 'the' 'time')! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'hfm 4/2/2010 13:52'!
-testMatchesInCollect	| matcher |	matcher := self matcherClass forString: '\w+'.	self assert: (matcher		matchesIn: 'now is the time'		collect: [ :each | each reversed ]) asArray			= #('won' 'si' 'eht' 'emit')! !
+testMatchesInCollect
+	| matcher |
+	matcher := self matcherClass forString: '\w+'.
+	self assert: (matcher
+		matchesIn: 'now is the time'
+		collect: [ :each | each reversed ]) asArray
+			= #('won' 'si' 'eht' 'emit')! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:44'!
-testMatchesInDo	| matcher expected |	matcher := self matcherClass forString: '\w+'.	expected := #('now' 'is' 'the' 'time') asOrderedCollection.	matcher 		matchesIn: 'now is the time'		do: [ :each | self assert: each = expected removeFirst ].	self assert: expected isEmpty! !
+testMatchesInDo
+	| matcher expected |
+	matcher := self matcherClass forString: '\w+'.
+	expected := #('now' 'is' 'the' 'time') asOrderedCollection.
+	matcher 
+		matchesIn: 'now is the time'
+		do: [ :each | self assert: each = expected removeFirst ].
+	self assert: expected isEmpty! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:39'!
-testMatchesOnStream	| matcher |	matcher := self matcherClass forString: '\w+'.	self assert: (matcher matchesOnStream: 'now is the time' readStream) asArray 		= #('now' 'is' 'the' 'time')! !
+testMatchesOnStream
+	| matcher |
+	matcher := self matcherClass forString: '\w+'.
+	self assert: (matcher matchesOnStream: 'now is the time' readStream) asArray 
+		= #('now' 'is' 'the' 'time')! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'hfm 4/2/2010 13:52'!
-testMatchesOnStreamCollect	| matcher |	matcher := self matcherClass forString: '\w+'.	self assert: (matcher 		matchesOnStream: 'now is the time' readStream 		collect: [ :each | each reversed ]) asArray			= #('won' 'si' 'eht' 'emit')! !
+testMatchesOnStreamCollect
+	| matcher |
+	matcher := self matcherClass forString: '\w+'.
+	self assert: (matcher 
+		matchesOnStream: 'now is the time' readStream 
+		collect: [ :each | each reversed ]) asArray
+			= #('won' 'si' 'eht' 'emit')! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:44'!
-testMatchesOnStreamDo	| matcher expected |	matcher := self matcherClass forString: '\w+'.	expected := #('now' 'is' 'the' 'time') asOrderedCollection.	matcher 		matchesOnStream: 'now is the time' readStream		do: [ :each | self assert: each = expected removeFirst ].	self assert: expected isEmpty! !
+testMatchesOnStreamDo
+	| matcher expected |
+	matcher := self matcherClass forString: '\w+'.
+	expected := #('now' 'is' 'the' 'time') asOrderedCollection.
+	matcher 
+		matchesOnStream: 'now is the time' readStream
+		do: [ :each | self assert: each = expected removeFirst ].
+	self assert: expected isEmpty! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:45'!
-testMatchesStream	| matcher |	matcher := self matcherClass forString: '\w+'.	self assert: (matcher matchesStream: 'now' readStream).	self deny: (matcher matchesStream: 'now is' readStream)! !
+testMatchesStream
+	| matcher |
+	matcher := self matcherClass forString: '\w+'.
+	self assert: (matcher matchesStream: 'now' readStream).
+	self deny: (matcher matchesStream: 'now is' readStream)! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'TestRunner 1/15/2010 20:51'!
-testMatchingRangesIn	| matcher expected |	matcher := self matcherClass forString: '\w+'.	expected := #(1 3 5 6 8 10 12 15) asOrderedCollection.	(matcher matchingRangesIn: 'now is the time') do: [ :range |		self assert: range first = expected removeFirst.		self assert: range last = expected removeFirst ].	self assert: expected isEmpty! !
+testMatchingRangesIn
+	| matcher expected |
+	matcher := self matcherClass forString: '\w+'.
+	expected := #(1 3 5 6 8 10 12 15) asOrderedCollection.
+	(matcher matchingRangesIn: 'now is the time') do: [ :range |
+		self assert: range first = expected removeFirst.
+		self assert: range last = expected removeFirst ].
+	self assert: expected isEmpty! !
 
 !RxMatcherTest methodsFor: 'testing' stamp: 'lr 1/15/2010 19:47'!
-testRegex001	self runRegex: #('^.*$' 		'' true (1 '')		'a' true (1 'a')		'abc' true (1 'abc'))! !
+testRegex001
+	self runRegex: #('^.*$' 
+		'' true (1 '')
+		'a' true (1 'a')
+		'abc' true (1 'abc'))! !
 
 !RxMatcherTest methodsFor: 'testing' stamp: 'lr 1/15/2010 19:47'!
-testRegex002	self runRegex: #('a\w+c'		' abb_bbc ' true (1 'abb_bbc')		'abb-bc' false nil)! !
+testRegex002
+	self runRegex: #('a\w+c'
+		' abb_bbc ' true (1 'abb_bbc')
+		'abb-bc' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing' stamp: 'lr 1/15/2010 19:47'!
-testRegex003	self runRegex: #('a\W+c'		' abb_bbc ' false nil		'abb-bc' false nil		'a.,:;-&!!"#%/()={[]}+?\~*''c' true (1 'a.,:;-&!!"#%/()={[]}+?\~*''c'))! !
+testRegex003
+	self runRegex: #('a\W+c'
+		' abb_bbc ' false nil
+		'abb-bc' false nil
+		'a.,:;-&!!"#%/()={[]}+?\~*''c' true (1 'a.,:;-&!!"#%/()={[]}+?\~*''c'))! !
 
 !RxMatcherTest methodsFor: 'testing' stamp: 'lr 4/23/2010 09:01'!
-testRegex004	self runRegex: #(':isVowel:'		'aei' true nil		'xyz' false nil)! !
+testRegex004
+	self runRegex: #(':isVowel:'
+		'aei' true nil
+		'xyz' false nil)! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'gsa 12/22/2012 12:26'!
 testStringAllRangesOfRegexMatches
@@ -593,91 +1032,345 @@ testStringAllRangesOfRegexMatches
 	! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'lr 4/23/2010 08:50'!
-testStringAllRegexMatches	| result |	result := 'aabbcc' allRegexMatches: 'b+'.	self assert: result size = 1.	self assert: result first = 'bb'! !
+testStringAllRegexMatches
+	| result |
+	result := 'aabbcc' allRegexMatches: 'b+'.
+	self assert: result size = 1.
+	self assert: result first = 'bb'! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'lr 4/23/2010 08:51'!
-testStringAsRegex	self assert: 'b+' asRegex class = RxParser preferredMatcherClass! !
+testStringAsRegex
+	self assert: 'b+' asRegex class = RxParser preferredMatcherClass! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'lr 4/23/2010 08:52'!
-testStringAsRegexIgnoringCase	self assert: 'b+' asRegexIgnoringCase class = RxParser preferredMatcherClass! !
+testStringAsRegexIgnoringCase
+	self assert: 'b+' asRegexIgnoringCase class = RxParser preferredMatcherClass! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'lr 4/23/2010 08:53'!
-testStringCopyWithRegexMatchesReplacedWith	self assert: ('aabbcc' copyWithRegex: 'b+' matchesReplacedWith: 'X') = 'aaXcc'! !
+testStringCopyWithRegexMatchesReplacedWith
+	self assert: ('aabbcc' copyWithRegex: 'b+' matchesReplacedWith: 'X') = 'aaXcc'! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'lr 4/23/2010 08:53'!
-testStringCopyWithRegexMatchesTranslatedUsing	self assert: ('aabbcc' 		copyWithRegex: 'b+' 		matchesTranslatedUsing: [ :each | 			self assert: each = 'bb'.			'X' ]) = 'aaXcc'! !
+testStringCopyWithRegexMatchesTranslatedUsing
+	self assert: ('aabbcc' 
+		copyWithRegex: 'b+' 
+		matchesTranslatedUsing: [ :each | 
+			self assert: each = 'bb'.
+			'X' ]) = 'aaXcc'! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'lr 4/23/2010 08:55'!
-testStringMatchesRegex	self deny: ('aabbcc' matchesRegex: 'a+').	self deny: ('aabbcc' matchesRegex: 'b+c+').	self assert: ('aabbcc' matchesRegex: 'a+b+c+')! !
+testStringMatchesRegex
+	self deny: ('aabbcc' matchesRegex: 'a+').
+	self deny: ('aabbcc' matchesRegex: 'b+c+').
+	self assert: ('aabbcc' matchesRegex: 'a+b+c+')! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'lr 4/23/2010 08:55'!
-testStringMatchesRegexIgnoringCase	self deny: ('AABBCC' matchesRegexIgnoringCase: 'a+').	self deny: ('AABBCC' matchesRegexIgnoringCase: 'b+c+').	self assert: ('AABBCC' matchesRegexIgnoringCase: 'a+b+c+')! !
+testStringMatchesRegexIgnoringCase
+	self deny: ('AABBCC' matchesRegexIgnoringCase: 'a+').
+	self deny: ('AABBCC' matchesRegexIgnoringCase: 'b+c+').
+	self assert: ('AABBCC' matchesRegexIgnoringCase: 'a+b+c+')! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'lr 4/23/2010 08:56'!
-testStringPrefixMatchesRegex	self assert: ('aabbcc' prefixMatchesRegex: 'a+').	self deny: ('aabbcc' prefixMatchesRegex: 'b+')! !
+testStringPrefixMatchesRegex
+	self assert: ('aabbcc' prefixMatchesRegex: 'a+').
+	self deny: ('aabbcc' prefixMatchesRegex: 'b+')! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'lr 4/23/2010 08:56'!
-testStringPrefixMatchesRegexIgnoringCase	self assert: ('AABBCC' prefixMatchesRegexIgnoringCase: 'a+').	self deny: ('AABBCC' prefixMatchesRegexIgnoringCase: 'b+')! !
+testStringPrefixMatchesRegexIgnoringCase
+	self assert: ('AABBCC' prefixMatchesRegexIgnoringCase: 'a+').
+	self deny: ('AABBCC' prefixMatchesRegexIgnoringCase: 'b+')! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'lr 4/23/2010 08:57'!
-testStringRegexMatchesCollect	| result |	result := 'aabbcc' regex: 'b+' matchesCollect: [ :each | each asUppercase ].	self assert: result size = 1.	self assert: result first = 'BB'! !
+testStringRegexMatchesCollect
+	| result |
+	result := 'aabbcc' regex: 'b+' matchesCollect: [ :each | each asUppercase ].
+	self assert: result size = 1.
+	self assert: result first = 'BB'! !
 
 !RxMatcherTest methodsFor: 'testing-extensions' stamp: 'lr 4/23/2010 08:58'!
-testStringRegexMatchesDo	| result |	result := OrderedCollection new.	'aabbcc' regex: 'b+' matchesDo: [ :each | result add: each ].	self assert: result size = 1.	self assert: result first = 'bb'! !
+testStringRegexMatchesDo
+	| result |
+	result := OrderedCollection new.
+	'aabbcc' regex: 'b+' matchesDo: [ :each | result add: each ].
+	self assert: result size = 1.
+	self assert: result first = 'bb'! !
 
 !RxMatcherTest methodsFor: 'testing-protocol' stamp: 'lr 1/15/2010 20:55'!
-testSubexpressionCount	| matcher |	#(('a' 1) ('a(b)' 2) ('a(b(c))' 3) ('(a)(b)' 3) ('(a(b))*' 3)) do: [ :pair |		matcher := self matcherClass forString: pair first.		matcher supportsSubexpressions 			ifTrue: [ self assert: matcher subexpressionCount = pair last ] ]! !
+testSubexpressionCount
+	| matcher |
+	#(('a' 1) ('a(b)' 2) ('a(b(c))' 3) ('(a)(b)' 3) ('(a(b))*' 3)) do: [ :pair |
+		matcher := self matcherClass forString: pair first.
+		matcher supportsSubexpressions 
+			ifTrue: [ self assert: matcher subexpressionCount = pair last ] ]! !
 
 !RxMatcherTest class methodsFor: 'accessing' stamp: 'lr 1/15/2010 19:48'!
-packageNamesUnderTest	^ #('VB-Regex')! !
+packageNamesUnderTest
+	^ #('VB-Regex')! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/5/2006 00:11'!
-DoesNotWorktestBackQuotesEscape	"self debug: #testBackQuotesEscape"		"Regular expressions can also include the following backquote escapesto refer to popular classes of characters:	\w	any word constituent character (same as [a-zA-Z0-9:=])	\W	any character but a word constituent	\d	a digit (same as [0-9])	\D	anything but a digit	\s 	a whitespace character	\S	anything but a whitespace characterThese escapes are also allowed in character classes: '[\w+-]' means'any character that is either a word constituent, or a plus, or aminus'."		self assert: ('one word' matchesRegex: '\w').				self assert: ('one' matchesRegex: '\w').		  		! !
+DoesNotWorktestBackQuotesEscape
+	"self debug: #testBackQuotesEscape"
+	
+	"Regular expressions can also include the following backquote escapes
+to refer to popular classes of characters:
+	\w	any word constituent character (same as [a-zA-Z0-9:=])
+	\W	any character but a word constituent
+	\d	a digit (same as [0-9])
+	\D	anything but a digit
+	\s 	a whitespace character
+	\S	anything but a whitespace character
+These escapes are also allowed in character classes: '[\w+-]' means
+'any character that is either a word constituent, or a plus, or a
+minus'."
+	
+	self assert: ('one word' matchesRegex: '\w').	
+		
+	self assert: ('one' matchesRegex: '\w').		  	
+	! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'StephaneDucasse 12/11/2010 15:00'!
-test	"self debug: #test"		self assert: ('\<t\w+' asRegexIgnoringCase		copy: 'now is the Time'		translatingMatchesUsing: [:match | match asUppercase]) = 'now is THE TIME'.	"the regular expression matches words beginning with either an uppercase or a lowercase T"! !
+test
+	"self debug: #test"
+	
+
+	self assert: ('\<t\w+' asRegexIgnoringCase
+		copy: 'now is the Time'
+		translatingMatchesUsing: [:match | match asUppercase]) = 'now is THE TIME'.
+
+	"the regular expression matches words beginning with either an uppercase or a lowercase T"! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/4/2006 16:24'!
-testCadrMatching	"self debug: #testCadrMatching"	"A bit more complex example is the following expression, matching thename of any of the Lisp-style `car', `cdr', `caar', `cadr',... functions:"	self assert: ( 'car' matchesRegex: 'c(a|d)+r').	self assert: ( 'cdr' matchesRegex: 'c(a|d)+r').	self assert: ( 'caar' matchesRegex: 'c(a|d)+r').	self assert: ( 'cadr' matchesRegex: 'c(a|d)+r').	self assert: ( 'caddar' matchesRegex: 'c(a|d)+r').! !
+testCadrMatching
+	"self debug: #testCadrMatching"
+
+	"A bit more complex example is the following expression, matching the
+name of any of the Lisp-style `car', `cdr', `caar', `cadr',
+... functions:"
+
+	self assert: ( 'car' matchesRegex: 'c(a|d)+r').
+	self assert: ( 'cdr' matchesRegex: 'c(a|d)+r').
+	self assert: ( 'caar' matchesRegex: 'c(a|d)+r').
+	self assert: ( 'cadr' matchesRegex: 'c(a|d)+r').
+	self assert: ( 'caddar' matchesRegex: 'c(a|d)+r').! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/4/2006 16:49'!
-testCharacterSet	"self debug: #testCharacterSet"		"So far, we have used only characters as the 'smallest' components ofregular expressions. There are other, more `interesting', components.A character set is a string of characters enclosed in squarebrackets. It matches any single character if it appears between thebrackets. For example, `[01]' matches either `0' or `1':"	self assert: ('0' matchesRegex: '[01]').	 		self deny: ('3' matchesRegex: '[01]'). 	 	self deny: ('11' matchesRegex: '[01]').	"-- false: a set matches only one character"	self deny: ('01' matchesRegex: '[01]').! !
+testCharacterSet
+	"self debug: #testCharacterSet"
+	
+	"So far, we have used only characters as the 'smallest' components of
+regular expressions. There are other, more `interesting', components.
+A character set is a string of characters enclosed in square
+brackets. It matches any single character if it appears between the
+brackets. For example, `[01]' matches either `0' or `1':"
+
+	self assert: ('0' matchesRegex: '[01]').	 	
+	self deny: ('3' matchesRegex: '[01]'). 	 
+	self deny: ('11' matchesRegex: '[01]').	"-- false: a set matches only one character"
+	self deny: ('01' matchesRegex: '[01]').
+! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/4/2006 17:39'!
-testCharacterSetBinaryNumber	"self debug: #testCharacterSetBinaryNumber"		"Using plus operator, we can build the following binary numberrecognizer:"	self assert: ('10010100' matchesRegex: '[01]+').	 		self deny: ('10001210' matchesRegex: '[01]+')	 ! !
+testCharacterSetBinaryNumber
+	"self debug: #testCharacterSetBinaryNumber"
+	
+	"Using plus operator, we can build the following binary number
+recognizer:"
+	self assert: ('10010100' matchesRegex: '[01]+').	 	
+	self deny: ('10001210' matchesRegex: '[01]+')	 ! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/5/2006 00:01'!
-testCharacterSetInversion	"self debug: #testCharacterSetInversion"		"If the first character after the opening bracket is `^', the set isinverted: it matches any single character *not* appearing between thebrackets:"		self deny: ('0' matchesRegex: '[^01]').		  		"0 appears in 01 so there is no match"		self assert: ('3' matchesRegex: '[^01]').	"3 is not in 01 so it matches"			self deny: ('30' matchesRegex: '[^01]').			self deny: ('33333333333333333333333330' matchesRegex: '[^01]').		"there is one zero so it does not match"! !
+testCharacterSetInversion
+	"self debug: #testCharacterSetInversion"
+	
+	"If the first character after the opening bracket is `^', the set is
+inverted: it matches any single character *not* appearing between the
+brackets:"
+	
+	self deny: ('0' matchesRegex: '[^01]').		  	
+	"0 appears in 01 so there is no match"
+	
+	self assert: ('3' matchesRegex: '[^01]').
+	"3 is not in 01 so it matches"
+	
+	
+	self deny: ('30' matchesRegex: '[^01]').		
+	self deny: ('33333333333333333333333330' matchesRegex: '[^01]').	
+	"there is one zero so it does not match"! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/4/2006 23:20'!
-testCharacterSetRange	"self debug: #testCharacterSetRange"		"For convenience, a set may include ranges: pairs of charactersseparated with `-'. This is equivalent to listing all charactersbetween them: `[0-9]' is the same as `[0123456789]'. "		self assert: ('0' matchesRegex: '[0-9]').		self assert: ('9' matchesRegex: '[0-9]').		self deny: ('a' matchesRegex: '[0-9]').	self deny: ('01' matchesRegex: '[0-9]').		self assert: ('01442128629839374565' matchesRegex: '[0-9]+').		! !
+testCharacterSetRange
+	"self debug: #testCharacterSetRange"
+	
+	"For convenience, a set may include ranges: pairs of characters
+separated with `-'. This is equivalent to listing all characters
+between them: `[0-9]' is the same as `[0123456789]'. "	
+
+	self assert: ('0' matchesRegex: '[0-9]').	
+	self assert: ('9' matchesRegex: '[0-9]').	
+	self deny: ('a' matchesRegex: '[0-9]').
+	self deny: ('01' matchesRegex: '[0-9]').	
+	self assert: ('01442128629839374565' matchesRegex: '[0-9]+').	
+	! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'marcus.denker 10/22/2008 10:47'!
-testMatchesInwW	"self debug: #testMatchesInwW"		"1. Backslash escapes similar to those in Perl are allowed in patterns:	\w	any word constituent character (equivalent to [a-zA-Z0-9:=])	\W	any character but a word constituent (equivalent to [^a-xA-Z0-9:=]"	self assert: ('\w+' asRegex matchesIn: 'now is the time') asArray = #('now' 'is' 'the' 'time').	self assert: ('\W+' asRegex matchesIn: 'now is the time') asArray = #(' ' ' ' ' ').		"why do we get that"	self assert: ('\w' asRegex matchesIn: 'now') asArray = #('n' 'o' 'w').! !
+testMatchesInwW
+	"self debug: #testMatchesInwW"
+	
+	"1. Backslash escapes similar to those in Perl are allowed in patterns:
+	\w	any word constituent character (equivalent to [a-zA-Z0-9:=])
+	\W	any character but a word constituent (equivalent to [^a-xA-Z0-9:=]"
+
+	self assert: ('\w+' asRegex matchesIn: 'now is the time') asArray = #('now' 'is' 'the' 'time').
+	self assert: ('\W+' asRegex matchesIn: 'now is the time') asArray = #(' ' ' ' ' ').
+	
+	"why do we get that"
+	self assert: ('\w' asRegex matchesIn: 'now') asArray = #('n' 'o' 'w').! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/4/2006 16:38'!
-testOrOperator	"self debug: #testOrOperator"		"The last operator is `|' meaning `or'. It is placed between tworegular expressions, and the resulting expression matches if one ofthe expressions matches. It has the lowest possible precedence (lowerthan sequencing). For example, `ab*|ba*' means `a followed by anynumber of b's, or b followed by any number of a's':"	self assert: ('abb' matchesRegex: 'ab*|ba*').  		self assert: ('baa' matchesRegex: 'ab*|ba*').	 		self deny: ('baab' matchesRegex: 'ab*|ba*').		"It is possible to write an expression matching an empty string, forexample: `a|'.  However, it is an error to apply `*', `+', or `?' tosuch expression: `(a|)*' is an invalid expression."	self should: ['(a|)*' asRegex] raise: Error.! !
+testOrOperator
+	"self debug: #testOrOperator"
+	
+	"The last operator is `|' meaning `or'. It is placed between two
+regular expressions, and the resulting expression matches if one of
+the expressions matches. It has the lowest possible precedence (lower
+than sequencing). For example, `ab*|ba*' means `a followed by any
+number of b's, or b followed by any number of a's':"
+
+	self assert: ('abb' matchesRegex: 'ab*|ba*').  	
+	self assert: ('baa' matchesRegex: 'ab*|ba*').	 	
+	self deny: ('baab' matchesRegex: 'ab*|ba*').
+	
+
+	"It is possible to write an expression matching an empty string, for
+example: `a|'.  However, it is an error to apply `*', `+', or `?' to
+such expression: `(a|)*' is an invalid expression."
+
+	self should: ['(a|)*' asRegex] raise: Error.
+! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/4/2006 16:17'!
-testQuotingOperators	"self debug: #testQuotingOperators"		"As we have seen, characters `*', `+', `?', `(', and `)' have specialmeaning in regular expressions. If one of them is to be usedliterally, it should be quoted: preceded with a backslash. (Thus,backslash is also special character, and needs to be quoted for aliteral match--as well as any other special character describedfurther)."	self deny: ('ab*' matchesRegex: 'ab*'). "	-- false: star in the right string is special"	self assert: ('ab*' matchesRegex: 'ab\*').	 			self assert: ('a\c' matchesRegex: 'a\\c').		 	! !
+testQuotingOperators
+	"self debug: #testQuotingOperators"
+	
+	"As we have seen, characters `*', `+', `?', `(', and `)' have special
+meaning in regular expressions. If one of them is to be used
+literally, it should be quoted: preceded with a backslash. (Thus,
+backslash is also special character, and needs to be quoted for a
+literal match--as well as any other special character described
+further)."
+
+	self deny: ('ab*' matchesRegex: 'ab*'). "	-- false: star in the right string is special"
+	self assert: ('ab*' matchesRegex: 'ab\*').	 		
+	self assert: ('a\c' matchesRegex: 'a\\c').		 	! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/3/2006 19:50'!
-testSimpleMatchesRegex	"self debug: #testSimpleMatchesRegex"		"The simplest regular expression is a single character.  It matchesexactly that character. A sequence of characters matches a string withexactly the same sequence of characters:"	self assert: ('a' matchesRegex: 'a').	self assert: ('foobar' matchesRegex: 'foobar')	.	self deny: ('blorple' matchesRegex: 'foobar')! !
+testSimpleMatchesRegex
+	"self debug: #testSimpleMatchesRegex"
+	
+	"The simplest regular expression is a single character.  It matches
+exactly that character. A sequence of characters matches a string with
+exactly the same sequence of characters:"
+
+	self assert: ('a' matchesRegex: 'a').
+	self assert: ('foobar' matchesRegex: 'foobar')	.
+	self deny: ('blorple' matchesRegex: 'foobar')! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/3/2006 21:41'!
-testSimpleMatchesRegexWithStar	"self debug: #testSimpleMatchesRegexWithStar"		"The above paragraph in testSimpleMatchesRegex introduced a primitive regular expression (acharacter), and an operator (sequencing). Operators are applied toregular expressions to produce more complex regular expressions.Sequencing (placing expressions one after another) as an operator is,in a certain sense, `invisible'--yet it is arguably the most common.A more `visible' operator is Kleene closure, more often simplyreferred to as `a star'.  A regular expression followed by an asteriskmatches any number (including 0) of matches of the originalexpression. For example:"	self assert: ('ab' matchesRegex: 'a*b').		 			self assert: ('aaaaab' matchesRegex: 'a*b').		self assert: ('b' matchesRegex: 'a*b').	 		self deny: ('aac' matchesRegex: 'a*b').	 		! !
+testSimpleMatchesRegexWithStar
+	"self debug: #testSimpleMatchesRegexWithStar"
+	
+	"The above paragraph in testSimpleMatchesRegex introduced a primitive regular expression (a
+character), and an operator (sequencing). Operators are applied to
+regular expressions to produce more complex regular expressions.
+Sequencing (placing expressions one after another) as an operator is,
+in a certain sense, `invisible'--yet it is arguably the most common.
+A more `visible' operator is Kleene closure, more often simply
+referred to as `a star'.  A regular expression followed by an asterisk
+matches any number (including 0) of matches of the original
+expression. For example:"
+
+	self assert: ('ab' matchesRegex: 'a*b').		 		
+	self assert: ('aaaaab' matchesRegex: 'a*b').	
+	self assert: ('b' matchesRegex: 'a*b').	 	
+	self deny: ('aac' matchesRegex: 'a*b').	 		! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/4/2006 23:38'!
-testSpecialCharacterInSetRange	"self debug: #testSpecialCharacterInSetRange"		"Special characters within a set are `^', `-', and `]' that closes theset. Below are the examples of how to literally use them in a set:	[01^]		-- put the caret anywhere except the beginning	[01-]		-- put the dash as the last character	[]01]		-- put the closing bracket as the first character 	[^]01]			(thus, empty and universal sets cannot be specified)"	self assert: ('0' matchesRegex: '[01^]').	self assert: ('1' matchesRegex: '[01^]').	self assert: ('^' matchesRegex: '[01^]').		self deny: ('0' matchesRegex: '[^01]').	self deny: ('1' matchesRegex: '[^01]').		"[^abc] means that everything except abc is matche"	self assert: ('^' matchesRegex: '[^01]').	! !
+testSpecialCharacterInSetRange
+	"self debug: #testSpecialCharacterInSetRange"
+	
+	"Special characters within a set are `^', `-', and `]' that closes the
+set. Below are the examples of how to literally use them in a set:
+	[01^]		-- put the caret anywhere except the beginning
+	[01-]		-- put the dash as the last character
+	[]01]		-- put the closing bracket as the first character 
+	[^]01]			(thus, empty and universal sets cannot be specified)"
+
+	self assert: ('0' matchesRegex: '[01^]').
+	self assert: ('1' matchesRegex: '[01^]').
+	self assert: ('^' matchesRegex: '[01^]').
+	
+	self deny: ('0' matchesRegex: '[^01]').
+	self deny: ('1' matchesRegex: '[^01]').
+	
+	"[^abc] means that everything except abc is matche"
+	self assert: ('^' matchesRegex: '[^01]').
+	! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/4/2006 16:26'!
-testStarPlusQuestionMark	"self debug: #testStarPlusQuestionMark"		"Two other operators similar to `*' are `+' and `?'. `+' (positiveclosure, or simply `plus') matches one or more occurrences of theoriginal expression. `?' (`optional') matches zero or one, but nevermore, occurrences."	self assert: ('ac' matchesRegex: 'ab*c').  			self deny: ('ac' matchesRegex: 'ab+c'). 		"-- false: need at least one b"	self assert: ('abbc' matchesRegex: 'ab+c').		self assert: ('abbbbbbc' matchesRegex: 'ab+c').		self deny: ('abbc' matchesRegex: 'ab?c')	 	"-- false: too many b's"! !
+testStarPlusQuestionMark
+	"self debug: #testStarPlusQuestionMark"
+	
+	"Two other operators similar to `*' are `+' and `?'. `+' (positive
+closure, or simply `plus') matches one or more occurrences of the
+original expression. `?' (`optional') matches zero or one, but never
+more, occurrences."
+
+	self assert: ('ac' matchesRegex: 'ab*c').  		
+	self deny: ('ac' matchesRegex: 'ab+c'). 		"-- false: need at least one b"
+	self assert: ('abbc' matchesRegex: 'ab+c').	
+	self assert: ('abbbbbbc' matchesRegex: 'ab+c').	
+	self deny: ('abbc' matchesRegex: 'ab?c')	 	"-- false: too many b's"! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/3/2006 22:57'!
-testStarPrecedence	"self debug: #testStarPrecedence"		"A star's precedence is higher than that of sequencing. A star appliesto the shortest possible subexpression that precedes it. For example,'ab*' means `a followed by zero or more occurrences of b', not `zeroor more occurrences of ab':"	self assert: ('abbb' matchesRegex: 'ab*'). 	self deny: ('abab' matchesRegex: 'ab*').	 				"To actually make a regex matching `zero or more occurrences of ab',`ab' is enclosed in parentheses:"	self assert: ('abab' matchesRegex: '(ab)*'). 	self deny: ('abcab' matchesRegex: '(ab)*')! !
+testStarPrecedence
+	"self debug: #testStarPrecedence"
+	
+	"A star's precedence is higher than that of sequencing. A star applies
+to the shortest possible subexpression that precedes it. For example,
+'ab*' means `a followed by zero or more occurrences of b', not `zero
+or more occurrences of ab':"
+
+	self assert: ('abbb' matchesRegex: 'ab*'). 
+	self deny: ('abab' matchesRegex: 'ab*').	 	
+		
+	"To actually make a regex matching `zero or more occurrences of ab',
+`ab' is enclosed in parentheses:"
+	self assert: ('abab' matchesRegex: '(ab)*'). 
+	self deny: ('abcab' matchesRegex: '(ab)*')! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'StephaneDucasse 12/11/2010 15:00'!
-testTranslatingMatchesUsing	"self debug: #testTranslatingMatchesUsing"		self assert: ('\<t\w+' asRegexIgnoringCase		copy: 'now is the Time'		translatingMatchesUsing: [:match | match asUppercase]) = 'now is THE TIME'.	"the regular expression matches words beginning with either an uppercase or a lowercase T"! !
+testTranslatingMatchesUsing
+	"self debug: #testTranslatingMatchesUsing"
+	
+
+	self assert: ('\<t\w+' asRegexIgnoringCase
+		copy: 'now is the Time'
+		translatingMatchesUsing: [:match | match asUppercase]) = 'now is THE TIME'.
+
+	"the regular expression matches words beginning with either an uppercase or a lowercase T"! !
 
 !RxParserTest methodsFor: 'tests' stamp: 'sd 9/4/2006 23:29'!
-toDotestSpecialCharacterInSetRange	"self debug: #testSpecialCharacterInSetRange"		"Special characters within a set are `^', `-', and `]' that closes theset. Below are the examples of how to literally use them in a set:	[01^]		-- put the caret anywhere except the beginning	[01-]		-- put the dash as the last character	[]01]		-- put the closing bracket as the first character 	[^]01]			(thus, empty and universal sets cannot be specified)"	self assert: ('0' matchesRegex: '[01^]').		self assert: ('0' matchesRegex: '[0-9]').		! !
+toDotestSpecialCharacterInSetRange
+	"self debug: #testSpecialCharacterInSetRange"
+	
+	"Special characters within a set are `^', `-', and `]' that closes the
+set. Below are the examples of how to literally use them in a set:
+	[01^]		-- put the caret anywhere except the beginning
+	[01-]		-- put the dash as the last character
+	[]01]		-- put the closing bracket as the first character 
+	[^]01]			(thus, empty and universal sets cannot be specified)"
+
+	self assert: ('0' matchesRegex: '[01^]').
+	
+	self assert: ('0' matchesRegex: '[0-9]').	
+	! !


### PR DESCRIPTION
Hi,

I've noticed that when you create an invalid regular expression such as

'[[:alpha]]' asRegex

The regex parser fails to raise a syntax error exception because it attempts to access a nil object. The problem is in
the RxCharSetParser match: method,

match: aCharacter

	aCharacter = lookahead
		ifFalse: [RxParser signalSyntaxException: 'unexpected character: ', (String with: lookahead)].
	^source atEnd
		ifTrue: [lookahead := nil]
		ifFalse: [lookahead := source next]

If the lookahead is nil (as is the case in the example) the attempt to create 'String with: lookahead' will fail.

I've added a test that raises a different error message in this case, and placed it in my fork. The fix is simple:

	aCharacter = lookahead
		ifFalse: [
			RxParser signalSyntaxException:
				(lookahead 
					ifNil:['missing character']
					ifNotNil:['unexpected character: ', (String with: lookahead)])

I guess you can simply replace these lines rather than merging the fork. 

Cheers :)
